### PR TITLE
Introduce async client-based callback API backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,11 @@ So now you don't have to sit in front of the machine all the time. You can quick
 * [Installation](#installation-arrow_down)
 * [Getting started with slackker callbacks](#getting-started-with-slackker-callbacks)
   * [Setup slackker](#setup-slackker)
+  * [Create a Client](#create-a-client)
   * [Use slackker callbacks for any python functions](#use-slackker-callbacks-for-any-python-functions)
   * [Use slackker callbacks with Keras](#use-slackker-callbacks-with-keras)
   * [Use slackker callbacks with Lightning](#use-slackker-callbacks-with-lightning)
+* [Legacy API (deprecated)](#legacy-api-deprecated)
 * [Support](#support-sparkles)
 * [Citation](#citation-page_facing_up)
 * [Maintainer](#maintainer-sunglasses)
@@ -58,40 +60,64 @@ pip install slackker
 * Slack: [How to setup slackker for your slack channel][setup-slack]
 * Telegram: [How to setup slackker for Telegram][setup-telegram]
 
+## Create a Client
+All slackker callbacks now use a **client** object. Create one for your platform first, then pass it to any callback.
+
+```python
+from slackker.core import SlackClient, TelegramClient
+```
+
+### Slack
+```python
+client = SlackClient(
+    token="xoxb-123234234235-123234234235-adedce74748c3844747aed",
+    channel="C04AAB77ABC",
+    verbose=0,
+)
+```
+
+### Telegram
+```python
+client = TelegramClient(
+    token="1234567890:AAAAA_A111BBBBBCCC2DD3eEe44f5GGGgGG",
+    verbose=0,
+)
+```
+
+**Parameters (shared):**
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `token` | `str` | _required_ | Slack app / Telegram bot token |
+| `channel` | `str` | _required (Slack only)_ | Slack channel ID to receive updates |
+| `chat_id` | `str` | `None` _(Telegram only)_ | Telegram chat ID. Auto-discovered if omitted |
+| `verbose` | `int` | `0` | `0` = no logging, `1` = info, `2` = debug |
+
 ## Use slackker callbacks for any python functions
 ![python-banner](https://brandslogos.com/wp-content/uploads/images/large/python-logo-1.png)
-Import basic slackker callbacks with following line:
-```python
-from slackker.callbacks.basic import SlackUpdate # for slack
-###################### OR ######################
-from slackker.callbacks.basic import TelegramUpdate # for telegram
-```
-Create slackker object.
-```python
-# for Slack
-slackker = SlackUpdate(token="xoxb-123234234235-123234234235-adedce74748c3844747aed",
-    channel="A04AAB77ABC")
-```
-or
-```python
-# for Telegram
-slackker = TelegramUpdate(token="1234567890:AAAAA_A111BBBBBCCC2DD3eEe44f5GGGgGG")
-```
-* `token`: _(string)_ Slack app/Telegram token
-* `channel`: _(string)_ Slack channel where you want to receive updates
-* `verbose`: _(int)_ default `0`: You can sent the verbose level up to 3.
-  * `verbose = 0` No logging
-  * `verbose = 1` Info logging
-  * `verbose = 2` Debug/In-depth logging
 
-Now you can wrap your function with this slackker object.
+### Import
+```python
+from slackker.core import SlackClient          # or TelegramClient
+from slackker.callbacks.simple import SimpleCallback
+```
+
+### Create the SimpleCallback object
+```python
+client = SlackClient(
+    token="xoxb-123234234235-123234234235-adedce74748c3844747aed",
+    channel="C04AAB77ABC",
+)
+
+slackker = SimpleCallback(client)
+```
+
+### Wrap your function with the `notifier` decorator
 ```python
 @slackker.notifier
 def your_function():
     return value_1, value_2
 ```
-following messages will be sent to your slack channel when the function executes.
-
+The following message will be sent to your channel when the function executes:
 ```text
 Function 'your_function' from Script: 'your_script.py' executed.
 Execution time: 5.006 Seconds
@@ -103,18 +129,17 @@ Output 1:
 value_2
 ```
 
-You can also use `slackker.notify(event=None, attachment=None, **kwargs)` at the end of your script to notify the end of script execution.
+### Send a notification with `notify()`
+You can also use `slackker.notify()` anywhere in your script to send a custom notification:
 ```python
-if __name__ == "__main__":
-    your_function()
-    slackker.notify(
-        event="training_complete",
-        value_1=arg1,
-        value_2=f"This is argument 2 = {arg2}",
-        status="completed"
-    )
+slackker.notify(
+    event="training_complete",
+    value_1=arg1,
+    value_2=f"This is argument 2 = {arg2}",
+    status="completed",
+)
 ```
-following message will be sent to your slack channel when the script ends.
+The following message will be sent:
 ```text
 Notification: training_complete at 14-10-2024 12:15:54
 
@@ -123,180 +148,213 @@ value_2: This is argument 2 = arg2
 status: completed
 ```
 
-If you want to send a file with the same update, pass the file path using `attachment`:
+To send a file with the notification, pass the file path using `attachment`:
 ```python
 slackker.notify(
     event="training_complete",
     attachment="./artifacts/model.ckpt",
     best_val_loss=0.0123,
-    epoch=20
+    epoch=20,
 )
 ```
+
+### Async support
+If you are working in an async context, use `async_notify()` directly:
+```python
+await slackker.async_notify(event="step_done", accuracy=0.95)
+```
+
 ### Final code for python function
 ```python
-from slackker.callbacks.basic import SlackUpdate
-###################### OR ######################
-from slackker.callbacks.basic import TelegramUpdate # for telegram
+from slackker.core import SlackClient
+from slackker.callbacks.simple import SimpleCallback
 
-# for Slack
-slackker = SlackUpdate(token="xoxb-123234234235-123234234235-adedce74748c3844747aed",
-    channel="A04AAB77ABC")
-###################### OR ######################
-# for Telegram
-slackker = TelegramUpdate(token="1234567890:AAAAA_A111BBBBBCCC2DD3eEe44f5GGGgGG")
+# Create client & SimpleCallback object
+client = SlackClient(
+    token="xoxb-123234234235-123234234235-adedce74748c3844747aed",
+    channel="C04AAB77ABC",
+)
+slackker = SimpleCallback(client)
 
 @slackker.notifier
 def your_function():
     return value_1, value_2
 
+your_function()
+
 slackker.notify(
     event="script_finished",
+    attachment="./artifacts/summary.txt",
     value_1=value_1,
     value_2=value_2,
-    attachment="./artifacts/summary.txt"
 )
 ```
+
 ## Use slackker callbacks with [Keras][keras]
 ![keras-banner](https://i.postimg.cc/MpLBBTn7/slackker-keras.png)
+
 ### Import slackker for Keras
-Import slackker callbacks for keras with following line:
 ```python
-from slackker.callbacks.keras import SlackUpdate # for slack
-###################### OR ######################
-from slackker.callbacks.keras import TelegramUpdate # for telegram
+from slackker.core import SlackClient          # or TelegramClient
+from slackker.callbacks.keras import KerasCallback
 ```
-### Create slackker object for keras
-Create slackker object.
-```python
-# for Slack
-slackker = SlackUpdate(token="xoxb-123234234235-123234234235-adedce74748c3844747aed",
-    channel="A04AAB77ABC",
-    ModelName='Keras_NN',
-    export='png',
-    SendPlot=True)
-```
-or
-```python
-# for Telegram
-slackker = TelegramUpdate(token="1234567890:AAAAA_A111BBBBBCCC2DD3eEe44f5GGGgGG",
-    ModelName='Simple_NN',
-    export='png',
-    SendPlot=True)
-```
-* `token`: _(string)_ Slack app/Telegram token
-* `channel`: _(string)_ Slack channel where you want to receive updates
-* `ModelName`: _(string)_ Name for your model. This same name will be used in future for title of the generated plots.
-* `export`: _(string)_ default `"png"`: Format for plots to be exported. _(supported formats: eps, jpeg, jpg, pdf, pgf, png, ps, raw, rgba, svg, svgz, tif, tiff)_
-* `SendPlots`: _(Bool)_ default `False`: If set to `True` it will export history of model, both training and validation, save it in the format given in `export` argument and send graphs to slack channel when training ends. If set to `False` it will not send exported graphs to slack channel. 
-* `verbose`: _(int)_ default `0`: You can sent the verbose level up to 3.
-  * `verbose = 0` No logging
-  * `verbose = 1` Info logging
-  * `verbose = 2` Debug/In-depth logging
 
-### Call slackker object into model.fit()
-
-Now you can call slackker object into callbacks argument just like any other callbacks object.
+### Create KerasCallback object
 ```python
-history = model.fit(x_train, 
-                    y_train,
-                    epochs = 3,
-                    batch_size = 16,
-                    verbose=1,
-                    validation_data=(x_val,y_val),
-                    callbacks=[slackker])
+client = SlackClient(
+    token="xoxb-123234234235-123234234235-adedce74748c3844747aed",
+    channel="C04AAB77ABC",
+)
+
+slackker = KerasCallback(
+    client=client,
+    model_name="Keras_NN",
+    export="png",
+    send_plot=True,
+)
+```
+or with Telegram:
+```python
+client = TelegramClient(
+    token="1234567890:AAAAA_A111BBBBBCCC2DD3eEe44f5GGGgGG",
+)
+
+slackker = KerasCallback(
+    client=client,
+    model_name="Simple_NN",
+    export="png",
+    send_plot=True,
+)
+```
+
+**KerasCallback Parameters:**
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `client` | `BaseClient` | _required_ | A `SlackClient` or `TelegramClient` instance |
+| `model_name` | `str` | _required_ | Name of your model (used in messages & plot titles) |
+| `export` | `str` | `"png"` | Plot export format _(eps, jpeg, jpg, pdf, pgf, png, ps, raw, rgba, svg, svgz, tif, tiff)_ |
+| `send_plot` | `bool` | `False` | If `True`, sends training/validation plots when training ends |
+
+### Call slackker object in model.fit()
+```python
+history = model.fit(
+    x_train, y_train,
+    epochs=3,
+    batch_size=16,
+    verbose=1,
+    validation_data=(x_val, y_val),
+    callbacks=[slackker],
+)
 ```
 
 ### Final code for Keras
 ```python
-# Import library for keras
-from slackker.callbacks.keras import slackUpdate
+from slackker.core import SlackClient
+from slackker.callbacks.keras import KerasCallback
 
-# Train-Test split for your keras model
+# Train-Test split
 x_train, x_test, y_train, y_test = train_test_split(x, y, train_size=0.8)
 x_train, x_val, y_train, y_val = train_test_split(x_train, y_train, train_size=0.8)
 
 # Build keras model
 model = Sequential()
-model.add(Dense(8,activation='relu',input_shape = (IMG_WIDTH, IMG_HEIGHT, DEPTH)))
-model.add(Dense(3,activation='softmax'))
-model.compile(optimizer = 'rmsprop', loss='categorical_crossentropy', metrics=['accuracy'])
+model.add(Dense(8, activation='relu', input_shape=(IMG_WIDTH, IMG_HEIGHT, DEPTH)))
+model.add(Dense(3, activation='softmax'))
+model.compile(optimizer='rmsprop', loss='categorical_crossentropy', metrics=['accuracy'])
 
-# Create Slackker object
-slackker = slackUpdate(token="xoxb-123234234235-123234234235-adedce74748c3844747aed48499bb",
-    channel="A04AAB77ABC",
-    modelName='SampleModel',
-    export='png',
-    sendPlot=True)
+# Create Client & KerasCallback
+client = SlackClient(
+    token="xoxb-123234234235-123234234235-adedce74748c3844747aed",
+    channel="C04AAB77ABC",
+)
 
-# Call Slackker object in model.fit() callbacks
-history = model.fit(x_train, 
-                    y_train,
-                    epochs = 3,
-                    batch_size = 16,
-                    verbose=1,
-                    validation_data=(x_val,y_val),
-                    callbacks=[slackker])
+slackker = KerasCallback(
+    client=client,
+    model_name="SampleModel",
+    export="png",
+    send_plot=True,
+)
+
+# Pass slackker to model.fit() callbacks
+history = model.fit(
+    x_train, y_train,
+    epochs=3,
+    batch_size=16,
+    verbose=1,
+    validation_data=(x_val, y_val),
+    callbacks=[slackker],
+)
 ```
+
 ## Use slackker callbacks with [Lightning][lightning]
 ![lightning-banner](https://i.postimg.cc/fR5Nqtcd/slackker-lightning.png)
+
 ### Import slackker for Lightning
-Import slackker callbacks for PyTorch Lightning with following line:
 ```python
-from slackker.callbacks.lightning import SlackUpdate # for slack
-###################### OR ######################
-from slackker.callbacks.lightning import TelegramUpdate # for telegram
+from slackker.core import SlackClient          # or TelegramClient
+from slackker.callbacks.lightning import LightningCallback
 ```
+
 ### Log your metrics to track
 #### Log Training loop metrics
 ```python
 self.log("train_loss", loss, on_epoch=True)
 self.log("train_acc", accuracy, on_epoch=True)
 ```
-Make sure to set `on_epoch=True` to in training step.
+Make sure to set `on_epoch=True` in the training step.
+
 #### Log Validation loop metrics
 ```python
 self.log("val_loss", loss)
 self.log("val_acc", accuracy)
 ```
-In Validation step `on_epoch=True` by default.
+In the validation step `on_epoch=True` by default.
 
-### Create slackker object for lightning
+### Create LightningCallback object
 ```python
-# for Slack
-slackker = SlackUpdate(token="xoxb-123234234235-123234234235-adedce74748c3844747aed",
-    channel="A04AAB77ABC",
-    ModelName='Lightning NN',
-    TrackLogs=['train_loss', 'train_acc', 'val_loss', 'val_acc'],
+client = SlackClient(
+    token="xoxb-123234234235-123234234235-adedce74748c3844747aed",
+    channel="C04AAB77ABC",
+)
+
+slackker = LightningCallback(
+    client=client,
+    model_name="Lightning NN",
+    track_logs=["train_loss", "train_acc", "val_loss", "val_acc"],
     monitor="val_loss",
-    export='png',
-    SendPlot=True)
+    export="png",
+    send_plot=True,
+)
 ```
-or
+or with Telegram:
 ```python
-# for Telegram
-slackker = TelegramUpdate(token="1234567890:AAAAA_A111BBBBBCCC2DD3eEe44f5GGGgGG",
-    ModelName="Lightning NN Testing",
-    TrackLogs=['train_loss', 'train_acc', 'val_loss', 'val_acc'],
+client = TelegramClient(
+    token="1234567890:AAAAA_A111BBBBBCCC2DD3eEe44f5GGGgGG",
+)
+
+slackker = LightningCallback(
+    client=client,
+    model_name="Lightning NN",
+    track_logs=["train_loss", "train_acc", "val_loss", "val_acc"],
     monitor="val_loss",
-    export='png',
-    SendPlot=True)
+    export="png",
+    send_plot=True,
+)
 ```
-* `token`: _(string)_ Slack app/Telegram token
-* `channel`: _(string)_ Slack channel where you want to receive updates
-* `ModelName`: _(string)_ Name for your model. This same name will be used in future for title of the generated plots.
-* `TrackLogs`: _(list)_ List of metrics you want slackker to track & notify.
-* `monitor`: _(string)_ This metric will be used to determine best Epoch
-* `export`: _(string)_ default `"png"`: Format for plots to be exported. _(supported formats: eps, jpeg, jpg, pdf, pgf, png, ps, raw, rgba, svg, svgz, tif, tiff)_
-* `SendPlots`: _(Bool)_ default `False`: If set to `True` it will export history of model, both training and validation, save it in the format given in `export` argument and send graphs to slack channel when training ends. If set to `False` it will not send exported graphs to slack channel. 
-* `verbose`: _(int)_ default `0`: You can sent the verbose level up to 3.
-  * `verbose = 0` No logging
-  * `verbose = 1` Info logging
-  * `verbose = 2` Debug/In-depth logging
+
+**LightningCallback Parameters:**
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `client` | `BaseClient` | _required_ | A `SlackClient` or `TelegramClient` instance |
+| `model_name` | `str` | _required_ | Name of your model (used in messages & plot titles) |
+| `track_logs` | `list[str]` | _required_ | List of metrics to track & report each epoch |
+| `monitor` | `str` | `None` | Metric used to determine the best epoch |
+| `export` | `str` | `"png"` | Plot export format _(eps, jpeg, jpg, pdf, pgf, png, ps, raw, rgba, svg, svgz, tif, tiff)_ |
+| `send_plot` | `bool` | `False` | If `True`, sends training plots when training ends |
 
 ### Call slackker object in Trainer module
-Now you can call slackker object into callbacks argument just like any other callbacks object.
 ```python
-trainer = Trainer(max_epochs=2,callbacks=[slackker])
+trainer = Trainer(max_epochs=2, callbacks=[slackker])
 ```
 
 ### Final code for Lightning
@@ -307,62 +365,46 @@ from torch.utils.data import DataLoader
 import torchvision as tv
 import torch.nn.functional as F
 from lightning.pytorch import LightningModule, Trainer
-from lightning.pytorch.callbacks import ModelCheckpoint, Callback
-from lightning.pytorch.loggers import CSVLogger
+from lightning.pytorch.callbacks import ModelCheckpoint
 
-from slackker.callbacks.lightning import SlackUpdate
-from slackker.callbacks.lightning import TelegramUpdate
+from slackker.core import SlackClient
+from slackker.callbacks.lightning import LightningCallback
 
 class LightningModel(LightningModule):
     def __init__(self):
         super().__init__()
-        self.fc1 = nn.Linear(28*28,256)
-        self.fc2 = nn.Linear(256,128)
-        self.out = nn.Linear(128,10)
+        self.fc1 = nn.Linear(28*28, 256)
+        self.fc2 = nn.Linear(256, 128)
+        self.out = nn.Linear(128, 10)
 
     def forward(self, x):
         batch_size, _, _, _ = x.size()
-        x = x.view(batch_size,-1)
+        x = x.view(batch_size, -1)
         x = F.relu(self.fc1(x))
         x = F.relu(self.fc2(x))
         return self.out(x)
 
     def configure_optimizers(self):
-        optimizer = torch.optim.Adam(self.parameters(), lr=1e-3)
-        return optimizer
+        return torch.optim.Adam(self.parameters(), lr=1e-3)
 
     def training_step(self, batch, batch_idx):
         x, y = batch
         y_hat = self.forward(x)
-
-        # calculate Loss
-        loss = F.cross_entropy(y_hat,y)
-
-        #calculate accuracy
+        loss = F.cross_entropy(y_hat, y)
         _, predictions = torch.max(y_hat, dim=1)
-        correct_predictions = torch.sum(predictions == y)
-        accuracy = correct_predictions / y.shape[0]
-
+        accuracy = torch.sum(predictions == y) / y.shape[0]
         self.log("train_loss", loss, on_epoch=True)
         self.log("train_acc", accuracy, on_epoch=True)
-
         return loss
 
     def validation_step(self, batch, batch_idx):
         x, y = batch
         y_hat = self.forward(x)
-
-        # calculate Loss
-        loss = F.cross_entropy(y_hat,y)
-
-        #calculate accuracy
+        loss = F.cross_entropy(y_hat, y)
         _, predictions = torch.max(y_hat, dim=1)
-        correct_predictions = torch.sum(predictions == y)
-        accuracy = correct_predictions / y.shape[0]
-
+        accuracy = torch.sum(predictions == y) / y.shape[0]
         self.log("val_loss", loss)
         self.log("val_acc", accuracy)
-
         return loss
 
 train_data = tv.datasets.MNIST(".", train=True, download=True, transform=tv.transforms.ToTensor())
@@ -372,18 +414,88 @@ test_loader = DataLoader(test_data, batch_size=128)
 
 model = LightningModel()
 
-# slackker checkpoint for slack
-slackker = SlackUpdate(token="xoxb-123234234235-123234234235-adedce74748c3844747aed",
-    channel="A04AAB77ABC",
-    ModelName='Lightning NN',
-    TrackLogs=['train_loss', 'train_acc', 'val_loss', 'val_acc'],
+# Create Client & LightningCallback
+client = SlackClient(
+    token="xoxb-123234234235-123234234235-adedce74748c3844747aed",
+    channel="C04AAB77ABC",
+)
+
+slackker = LightningCallback(
+    client=client,
+    model_name="Lightning NN",
+    track_logs=["train_loss", "train_acc", "val_loss", "val_acc"],
     monitor="val_loss",
-    export='png',
-    SendPlot=True)
+    export="png",
+    send_plot=True,
+)
 
 trainer = Trainer(max_epochs=2, callbacks=[slackker])
 trainer.fit(model, train_loader, test_loader)
 ```
+
+---
+
+# Legacy API (deprecated)
+
+> **Note:** The old `Update`, `SlackUpdate`, and `TelegramUpdate` classes still work but emit a `DeprecationWarning`. They will be removed in a future release. Please migrate to `SimpleCallback` and the new client-based API shown above.
+
+<details>
+<summary><strong>Click to expand legacy usage examples</strong></summary>
+
+### Basic callbacks (legacy)
+```python
+from slackker.callbacks.basic import SlackUpdate   # or TelegramUpdate
+
+# Slack
+slackker = SlackUpdate(
+    token="xoxb-123234234235-123234234235-adedce74748c3844747aed",
+    channel="C04AAB77ABC",
+)
+
+# Telegram
+slackker = TelegramUpdate(token="1234567890:AAAAA_A111BBBBBCCC2DD3eEe44f5GGGgGG")
+
+@slackker.notifier
+def your_function():
+    return value_1, value_2
+
+slackker.notify(event="done", value_1=value_1)
+```
+
+### Keras callbacks (legacy)
+```python
+from slackker.callbacks.keras import SlackUpdate   # or TelegramUpdate
+
+slackker = SlackUpdate(
+    token="xoxb-123234234235-123234234235-adedce74748c3844747aed",
+    channel="C04AAB77ABC",
+    ModelName="Keras_NN",
+    export="png",
+    SendPlot=True,
+)
+
+history = model.fit(..., callbacks=[slackker])
+```
+
+### Lightning callbacks (legacy)
+```python
+from slackker.callbacks.lightning import SlackUpdate   # or TelegramUpdate
+
+slackker = SlackUpdate(
+    token="xoxb-123234234235-123234234235-adedce74748c3844747aed",
+    channel="C04AAB77ABC",
+    ModelName="Lightning NN",
+    TrackLogs=["train_loss", "train_acc", "val_loss", "val_acc"],
+    monitor="val_loss",
+    export="png",
+    SendPlot=True,
+)
+
+trainer = Trainer(max_epochs=2, callbacks=[slackker])
+trainer.fit(model, train_loader, test_loader)
+```
+
+</details>
 
 #  Support :sparkles:
 If you get stuck, we’re here to help. The following are the best ways to get assistance working through your issue:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "slackker"
-version = "1.2.39"
+version = "1.3.0"
 description = "Python package for monitoring your python script & Model training status in real-time on slack & telegram."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,10 @@ dependencies = [
     "matplotlib>=3.7.5",
     "numpy>=1.24.4",
     "slack-sdk>=3.39.0",
+    "loguru>=0.7.0",
+    "httpx>=0.27.0",
+    "aiohttp>=3.9.0",
+    "requests>=2.31.0",
 ]
 license = "Apache-2.0"
 classifiers = [
@@ -62,4 +66,5 @@ dev = [
     "tensorflow>=2.21.0",
     "torchaudio>=2.11.0",
     "torchvision>=0.26.0",
+    "pytest-asyncio>=1.3.0",
 ]

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,6 +4,7 @@ python_files = test_*.py
 python_classes = Test*
 python_functions = test_*
 addopts = -v --tb=short
+asyncio_mode = auto
 markers =
     integration: integration tests
     unit: unit tests

--- a/slackker/__init__.py
+++ b/slackker/__init__.py
@@ -1,10 +1,10 @@
 from slackker import callbacks
-from slackker.utils import checkker
-from slackker.utils import functions
+from slackker.core import SlackClient, TelegramClient, BaseClient
+from slackker.callbacks.simple import SimpleCallback
 
 __author__ = 'Siddhesh Gunjal'
 __email__ = 'siddhu19@live.com'
-__version__ = '1.2.39'
+__version__ = '1.3.0'
 
 # module level doc-string
 __doc__ = """
@@ -12,9 +12,32 @@ slackker
 =====================================================================
 Description
 -----------
-slackker is a python package for monitoring your python script & Model training status in real-time on slack & telegram.
+slackker is a python package for sending notifications and monitoring
+your python scripts & ML model training in real-time on Slack & Telegram.
+
+Async-first with sync convenience wrappers. Works with any client
+backend via the BaseClient abstraction.
+
+New API (recommended):
+    from slackker.core import SlackClient, TelegramClient
+    from slackker.callbacks.simple import SimpleCallback
+    from slackker.callbacks.keras import KerasCallback
+    from slackker.callbacks.lightning import LightningCallback
+
+Legacy API (deprecated, still works):
+    from slackker.callbacks.basic import Update, SlackUpdate, TelegramUpdate
+    from slackker.callbacks.keras import SlackUpdate, TelegramUpdate
+    from slackker.callbacks.lightning import SlackUpdate, TelegramUpdate
 
 References
 ----------
 https://github.com/siddheshgunjal/slackker
 """
+
+__all__ = [
+    "SlackClient",
+    "TelegramClient",
+    "BaseClient",
+    "SimpleCallback",
+    "callbacks",
+]

--- a/slackker/callbacks/__init__.py
+++ b/slackker/callbacks/__init__.py
@@ -1,0 +1,4 @@
+from slackker.callbacks.simple import SimpleCallback
+from slackker.callbacks.basic import Update, SlackUpdate, TelegramUpdate
+
+__all__ = ["SimpleCallback", "Update", "SlackUpdate", "TelegramUpdate"]

--- a/slackker/callbacks/basic.py
+++ b/slackker/callbacks/basic.py
@@ -1,154 +1,70 @@
-import time
-import os
-from inspect import stack
-from datetime import datetime
-from slack_sdk import WebClient
-from slackker.utils import checkker
-from slackker.utils import functions
-from slackker.utils.ccolors import colors
+"""
+Deprecated module. Use slackker.callbacks.simple instead.
 
-class SlackUpdate():
-    ''' SlackUpdate class to send updates to Telegram channel '''
+This module is kept for backward compatibility only.
+"""
+
+import warnings
+from slackker.callbacks.simple import SimpleCallback
+from slackker.core.client import _run_sync as _sync
+from slackker.core.slack import SlackClient
+from slackker.core.telegram import TelegramClient
+from slackker.utils.logger import log
+
+
+class Update(SimpleCallback):
+    """Deprecated: Use SimpleCallback from slackker.callbacks.simple instead."""
+
+    def __init__(self, client):
+        warnings.warn(
+            "Update is deprecated. Use SimpleCallback(client) from slackker.callbacks.simple instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(client)
+
+
+# ──────────────────────────────────────────────
+# Backward-compatible shims (deprecated)
+# ──────────────────────────────────────────────
+
+class SlackUpdate(SimpleCallback):
+    """Deprecated: Use SimpleCallback(SlackClient(...)) instead."""
+
     def __init__(self, token, channel, verbose=0):
-
+        warnings.warn(
+            "SlackUpdate is deprecated. Use SimpleCallback(SlackClient(token, channel)) instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         if token is None:
-            colors.prRed('[slackker] ERROR: Please enter Valid Slack API Token.')
+            log.error("Please enter a valid Slack API Token.")
             return
 
-        server = checkker.check_internet(url="www.telegram.org", verbose=verbose)
-        api = checkker.slack_connect(token=token, verbose=verbose)
+        client = SlackClient(token=token, channel=channel, verbose=verbose)
+        connected = _sync(client.connect())
+        if connected:
+            super().__init__(client)
+        else:
+            log.error("Failed to connect to Slack.")
 
-        if server and api:
-            self.client = WebClient(token=token)
-            self.channel = channel
-            self.verbose = verbose
-        
-    def notifier(self, function):
-        ''' Decorator to log function calls '''
-        def wrapper(*args, **kwargs):
-            if self.verbose > 0:
-                # Log the function call
-                colors.prCyan(f"[slackker] INFO: Calling {function.__name__} with args: {args}, kwargs: {kwargs}")
-            
-            # Call the original function
-            start_time = time.time()
-            result = function(*args, **kwargs)
-            end_time = time.time()
 
-            # execution time
-            execution_time = end_time - start_time
+class TelegramUpdate(SimpleCallback):
+    """Deprecated: Use SimpleCallback(TelegramClient(...)) instead."""
 
-            if result is not None:
-                if isinstance(result, tuple):
-                    message = f"Function '{function.__name__}' from Script: '{os.path.basename(__import__(function.__module__).__file__)}' executed.\nExecution time: {execution_time:.3f} Seconds\nReturned {len(result)} outputs:\n"
-                    num = 0
-                    for i in result:
-                        message += f"Output {num}:\n{i}\n\n"
-                        num += 1
-                else:
-                    message = f"Function '{function.__name__}' from Script: '{os.path.basename(__import__(function.__module__).__file__)}' executed.\nExecution time: {execution_time:.3f} Seconds\nReturned output: {result}"
-            else:
-                message = f"Function '{function.__name__}' from Script: '{os.path.basename(__import__(function.__module__).__file__)}' executed.\nExecution time: {execution_time:.3f} Seconds\nReturned output: None"
-
-            # Log the return value
-            functions.Slack.report_stats(
-                client=self.client,
-                channel=self.channel,
-                text=message,
-                verbose=self.verbose
-            )
-
-            return result
-        return wrapper
-    
-    def notify(self, event: str = None, attachment: str = None, **kwargs):
-        ''' Notify the user that the script has been executed '''
-        
-        script = stack()[1].filename
-        
-        text = f"Notification: {event if event else os.path.basename(script)} at {datetime.now().strftime('%d-%m-%Y %H:%M:%S')}"
-
-        if kwargs:
-            for key, value in kwargs.items():
-                text += f"\n{key}: {value}"
-
-        functions.Slack.report_stats(
-            client=self.client,
-            channel=self.channel,
-            text=text,
-            attachment=attachment,
-            verbose=self.verbose
-        )
-
-class TelegramUpdate():
-    ''' TelegramUpdate class to send updates to Telegram channel '''
     def __init__(self, token, verbose=0):
-
+        warnings.warn(
+            "TelegramUpdate is deprecated. Use SimpleCallback(TelegramClient(token)) instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         if token is None:
-            colors.prRed('[slackker] ERROR: Please enter Valid Telegram API Token.')
+            log.error("Please enter a valid Telegram API Token.")
             return
 
-        server = checkker.check_internet(url="www.telegram.org", verbose=verbose)
-        channel = checkker.get_telegram_chat_id(token=token, verbose=verbose)
-
-        if server and channel:
-            self.token = token
-            self.channel = channel
-            self.verbose = verbose
-        
-    def notifier(self, function):
-        ''' Decorator to log function calls '''
-        def wrapper(*args, **kwargs):
-            if self.verbose > 0:
-                # Log the function call
-                colors.prCyan(f"[slackker] INFO: Calling {function.__name__} with args: {args}, kwargs: {kwargs}")
-            
-            # Call the original function
-            start_time = time.time()
-            result = function(*args, **kwargs)
-            end_time = time.time()
-
-            # execution time
-            execution_time = end_time - start_time
-
-            if result is not None:
-                if isinstance(result, tuple):
-                    message = f"Function '{function.__name__}' from Script: '{os.path.basename(__import__(function.__module__).__file__)}' executed.\nExecution time: {execution_time:.3f} Seconds\nReturned {len(result)} outputs:\n"
-                    num = 0
-                    for i in result:
-                        message += f"Output {num}:\n{i}\n\n"
-                        num += 1
-                else:
-                    message = f"Function '{function.__name__}' from Script: '{os.path.basename(__import__(function.__module__).__file__)}' executed.\nExecution time: {execution_time:.3f} Seconds\nReturned output: {result}"
-            else:
-                message = f"Function '{function.__name__}' from Script: '{os.path.basename(__import__(function.__module__).__file__)}' executed.\nExecution time: {execution_time:.3f} Seconds\nReturned output: None"
-
-            # Log the return value
-            functions.Telegram.report_stats(
-                token=self.token,
-                channel=self.channel,
-                text=message,
-                verbose=self.verbose
-            )
-
-            return result
-        return wrapper
-    
-    def notify(self, event: str = None, attachment: str = None, **kwargs):
-        ''' Notify the user that the script has been executed '''
-
-        script = stack()[1].filename
-        
-        text = f"Notification: {event if event else os.path.basename(script)} at {datetime.now().strftime('%d-%m-%Y %H:%M:%S')}"
-
-        if kwargs:
-            for key, value in kwargs.items():
-                text += f"\n{key}: {value}"
-
-        functions.Telegram.report_stats(
-            token=self.token,
-            channel=self.channel,
-            text=text,
-            attachment=attachment,
-            verbose=self.verbose
-        )
+        client = TelegramClient(token=token, verbose=verbose)
+        connected = _sync(client.connect())
+        if connected:
+            super().__init__(client)
+        else:
+            log.error("Failed to connect to Telegram.")

--- a/slackker/callbacks/keras.py
+++ b/slackker/callbacks/keras.py
@@ -1,196 +1,154 @@
+import warnings
 from datetime import datetime
-import argparse
-import requests
 import numpy as np
 from keras.callbacks import Callback
-from slack_sdk import WebClient
-from slackker.utils import checkker
-from slackker.utils import functions
-from slackker.utils.ccolors import colors
+from slackker.core.client import BaseClient, _run_sync
+from slackker.utils.logger import log
+from slackker.utils import network, plotting
 
-class SlackUpdate(Callback):
-    """Custom Keras callback that posts to Slack while training a neural network"""
+
+class KerasCallback(Callback):
+    """Unified Keras training callback that works with any client backend."""
+
+    SUPPORTED_FORMATS = ("eps", "jpeg", "jpg", "pdf", "pgf", "png", "ps", "raw", "rgba", "svg", "svgz", "tif", "tiff")
+
+    def __init__(self, client: BaseClient, model_name: str, export: str = "png", send_plot: bool = False):
+        super().__init__()
+        if export not in self.SUPPORTED_FORMATS:
+            raise ValueError(f"Unsupported export format '{export}'. Supported: {self.SUPPORTED_FORMATS}")
+
+        self.client = client
+        self.model_name = model_name
+        self.export = export
+        self.send_plot = send_plot
+
+        if not client.is_connected:
+            _run_sync(client.connect())
+
+        self.train_acc = []
+        self.valid_acc = []
+        self.train_loss = []
+        self.valid_loss = []
+        self.n_epochs = 0
+
+    def on_train_begin(self, logs=None):
+        self.client.send_message_sync(
+            f'Training on "{self.model_name}" started at {datetime.now().strftime("%Y-%m-%d %H:%M:%S")}'
+        )
+
+    def on_epoch_end(self, batch, logs=None):
+        logs = logs or {}
+        log_values = list(logs.values())
+
+        if len(log_values) >= 4:
+            self.train_acc.append(log_values[0])
+            self.train_loss.append(log_values[1])
+            self.valid_acc.append(log_values[2])
+            self.valid_loss.append(log_values[3])
+
+        message = f"Epoch: {self.n_epochs}"
+        if self.train_loss:
+            message += f", Training Loss: {self.train_loss[-1]:.4f}"
+        if self.valid_loss:
+            message += f", Validation Loss: {self.valid_loss[-1]:.4f}"
+
+        connected = _run_sync(
+            network.check_connection_quick(url="www.slack.com" if self.client.platform == "slack" else "www.telegram.org")
+        )
+        if connected:
+            self.client.send_message_sync(message)
+
+        self.n_epochs += 1
+
+    def on_train_end(self, logs=None):
+        if self.valid_loss:
+            best_epoch = int(np.argmin(self.valid_loss))
+            val_loss = self.valid_loss[best_epoch]
+            train_loss = self.train_loss[best_epoch]
+            val_acc = self.valid_acc[best_epoch] if self.valid_acc else 0
+            train_acc = self.train_acc[best_epoch] if self.train_acc else 0
+
+            self.client.send_message_sync(
+                f"Trained for {self.n_epochs} epochs. Best epoch was {best_epoch}."
+            )
+            self.client.send_message_sync(
+                f"Best validation loss = {val_loss:.4f}, Training Loss = {train_loss:.4f}, Best Accuracy = {100*val_acc:.4f}%"
+            )
+
+        training_logs = {
+            "train_loss": self.train_loss,
+            "train_acc": self.train_acc,
+            "val_loss": self.valid_loss,
+            "val_acc": self.valid_acc,
+        }
+
+        if self.send_plot:
+            paths = plotting.generate_and_get_plots(self.model_name, self.export, training_logs)
+            for path in paths:
+                self.client.upload_image_sync(path, comment=f"{self.model_name} 📎")
+
+
+# ──────────────────────────────────────────────
+# Backward-compatible shims (deprecated)
+# ──────────────────────────────────────────────
+
+from slackker.core.slack import SlackClient
+from slackker.core.telegram import TelegramClient
+
+
+class SlackUpdate(KerasCallback):
+    """Deprecated: Use KerasCallback(SlackClient(...), ...) instead."""
+
     def __init__(self, token, channel, ModelName, export="png", SendPlot=False, verbose=0):
-
+        warnings.warn(
+            "SlackUpdate is deprecated. Use KerasCallback(SlackClient(token, channel), model_name) instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         if token is None:
-            colors.prRed('[slackker] ERROR: Please enter Valid Slack API Token.')
+            log.error("Please enter a valid Slack API Token.")
             return
 
-        server = checkker.check_internet(url="www.slack.com", verbose=verbose)
-        api = checkker.slack_connect(token=token, verbose=verbose)
+        client = SlackClient(token=token, channel=channel, verbose=verbose)
+        connected = _run_sync(client.connect())
+        if not connected:
+            log.error("Failed to connect to Slack.")
+            return
 
-        if server and api:
-            self.client = WebClient(token=token)
-            self.channel = channel
-            self.ModelName = ModelName
-            self.export = export
-            self.SendPlot = SendPlot
-            self.verbose = verbose
+        super().__init__(client=client, model_name=ModelName, export=export, send_plot=SendPlot)
 
-            if export is not None:
-                pass
-            else:
-                raise argparse.ArgumentTypeError("[slackker] ERROR: 'export' argument is missing (supported formats: eps, jpeg, jpg, pdf, pgf, png, ps, raw, rgba, svg, svgz, tif, tiff)")
+        # Expose old attribute names for backward compat
+        self.ModelName = ModelName
+        self.SendPlot = SendPlot
+        self.verbose = verbose
+        self._sdk_client = client._client
+        self.channel = channel
 
-        self.train_acc = []
-        self.valid_acc = []
-        self.train_loss = []
-        self.valid_loss = []
-        self.n_epochs = 0
 
-    # Called when training starts
-    def on_train_begin(self, logs={}):
-        functions.Slack.report_stats(
-            client=self.client,
-            channel=self.channel,
-            text=f'Training on "{self.ModelName}" started at {datetime.now().strftime("%Y-%m-%d %H:%M:%S")}',
-            verbose=self.verbose)
+class TelegramUpdate(KerasCallback):
+    """Deprecated: Use KerasCallback(TelegramClient(...), ...) instead."""
 
-    # Called when epoch ends
-    def on_epoch_end(self, batch, logs={}):
-
-        custom_logs = []
-
-        for i in logs:
-            custom_logs.append(logs[i])
-
-        self.train_loss.append(custom_logs[1])
-        self.train_acc.append(custom_logs[0])
-        self.valid_loss.append(custom_logs[3])
-        self.valid_acc.append(custom_logs[2])
-
-        message = f'Epoch: {self.n_epochs}, Training Loss: {self.train_loss[-1]:.4f}, Validation Loss: {self.valid_loss[-1]:.4f}'
-
-        # Check internet before sending update on slacj
-        server = checkker.check_internet_epoch_end(url="www.slack.com")
-
-        # If internet working send message else skip sending message and continue training.
-        if server:
-            functions.Slack.report_stats(
-                client=self.client,
-                channel=self.channel,
-                text=message,
-                verbose=self.verbose)
-        else:
-            pass
-
-        self.n_epochs += 1
-
-    # Prepare and send report with graphs at the end of training.
-    def on_train_end(self, logs={}):
-
-        best_epoch = np.argmin(self.valid_loss)
-        val_loss = self.valid_loss[best_epoch]
-        train_loss = self.train_loss[best_epoch]
-        train_acc = self.train_acc[best_epoch]
-        val_acc = self.valid_acc[best_epoch]
-
-        training_logs = {'train_loss': self.train_loss, 'train_acc': self.train_acc, 'val_loss': self.valid_loss, 'val_acc': self.valid_acc}
-
-        message1 = f'Trained for {self.n_epochs} epochs. Best epoch was {best_epoch}.'
-        message2 = f"Best validation loss = {val_loss:.4f}, Training Loss = {train_loss:.4f}, Best Accuracy = {100*val_acc:.4f}%"
-
-        functions.Slack.report_stats(client=self.client, channel=self.channel, text=message1, verbose=self.verbose)
-
-        functions.Slack.report_stats(client=self.client, channel=self.channel, text=message2, verbose=self.verbose)
-
-        functions.Slack.keras_plot_history(ModelName=self.ModelName,
-            export=self.export,
-            client=self.client,
-            channel=self.channel,
-            SendPlot=self.SendPlot,
-            training_logs=training_logs,
-            verbose=self.verbose)
-
-class TelegramUpdate(Callback):
-    """Custom Keras callback that posts to Telegram while training a neural network"""
     def __init__(self, token, ModelName, export="png", SendPlot=False, verbose=0):
-
+        warnings.warn(
+            "TelegramUpdate is deprecated. Use KerasCallback(TelegramClient(token), model_name) instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         if token is None:
-            colors.prRed('[slackker] ERROR: Please enter Valid Telegram API Token.')
+            log.error("Please enter a valid Telegram API Token.")
             return
 
-        server = checkker.check_internet(url="www.telegram.org", verbose=verbose)
-        channel = checkker.get_telegram_chat_id(token=token, verbose=verbose)
+        client = TelegramClient(token=token, verbose=verbose)
+        connected = _run_sync(client.connect())
+        if not connected:
+            log.error("Failed to connect to Telegram.")
+            return
 
-        if server and channel:
-            self.token = token
-            self.channel = channel
-            self.ModelName = ModelName
-            self.export = export
-            self.SendPlot = SendPlot
-            self.verbose = verbose
+        super().__init__(client=client, model_name=ModelName, export=export, send_plot=SendPlot)
 
-            if export is not None:
-                pass
-            else:
-                raise argparse.ArgumentTypeError("[slackker] ERROR: 'export' argument is missing (supported formats: eps, jpeg, jpg, pdf, pgf, png, ps, raw, rgba, svg, svgz, tif, tiff)")
-
-        self.train_acc = []
-        self.valid_acc = []
-        self.train_loss = []
-        self.valid_loss = []
-        self.n_epochs = 0
-
-    # Called when training starts
-    def on_train_begin(self, logs={}):
-        functions.Telegram.report_stats(
-            token=self.token,
-            channel=self.channel,
-            text=f'Training on "{self.ModelName}" started at {datetime.now().strftime("%Y-%m-%d %H:%M:%S")}',
-            verbose=self.verbose)
-
-    # Called when epoch ends
-    def on_epoch_end(self, batch, logs={}):
-
-        custom_logs = []
-
-        for i in logs:
-            custom_logs.append(logs[i])
-
-        self.train_loss.append(custom_logs[1])
-        self.train_acc.append(custom_logs[0])
-        self.valid_loss.append(custom_logs[3])
-        self.valid_acc.append(custom_logs[2])
-        self.n_epochs += 1
-
-        message = f'Epoch: {self.n_epochs}, Training Loss: {self.train_loss[-1]:.4f}, Validation Loss: {self.valid_loss[-1]:.4f}'
-
-        # Check internet before sending update on slacj
-        server = checkker.check_internet_epoch_end(url="www.telegram.org")
-
-        # If internet working send message else skip sending message and continue training.
-        if server:
-            functions.Telegram.report_stats(
-                token=self.token,
-                channel=self.channel,
-                text=message,
-                verbose=self.verbose)
-        else:
-            pass
-
-    # Prepare and send report with graphs at the end of training.
-    def on_train_end(self, logs={}):
-
-        best_epoch = np.argmin(self.valid_loss)
-        val_loss = self.valid_loss[best_epoch]
-        train_loss = self.train_loss[best_epoch]
-        train_acc = self.train_acc[best_epoch]
-        val_acc = self.valid_acc[best_epoch]
-
-        training_logs = {'train_loss': self.train_loss, 'train_acc': self.train_acc, 'val_loss': self.valid_loss, 'val_acc': self.valid_acc}
-
-        message1 = f'Trained for {self.n_epochs} epochs. Best epoch was {best_epoch}.'
-        message2 = f"Best validation loss = {val_loss:.4f}, Training Loss = {train_loss:.4f}, Best Accuracy = {100*val_acc:.4f}%"
-
-        functions.Telegram.report_stats(token=self.token, channel=self.channel, text=message1, verbose=self.verbose)
-
-        functions.Telegram.report_stats(token=self.token, channel=self.channel, text=message2, verbose=self.verbose)
-
-        functions.Telegram.keras_plot_history(ModelName=self.ModelName,
-            export=self.export,
-            token=self.token,
-            channel=self.channel,
-            SendPlot=self.SendPlot,
-            training_logs=training_logs,
-            verbose=self.verbose)
+        # Expose old attribute names for backward compat
+        self.ModelName = ModelName
+        self.SendPlot = SendPlot
+        self.verbose = verbose
+        self.token = token
+        self.channel = client.chat_id

--- a/slackker/callbacks/lightning.py
+++ b/slackker/callbacks/lightning.py
@@ -1,240 +1,179 @@
 import sys
+import warnings
 from datetime import datetime
-import argparse
-import requests
 import numpy as np
 from lightning.pytorch.callbacks import Callback
-from slack_sdk import WebClient
-from slackker.utils import checkker
-from slackker.utils import functions
-from slackker.utils.ccolors import colors
+from slackker.core.client import BaseClient, _run_sync
+from slackker.utils.logger import log
+from slackker.utils import network, plotting
 
-class SlackUpdate(Callback):
-    """Custom Lightning callback that posts to Slack while training a neural network"""
+
+class LightningCallback(Callback):
+    """Unified Lightning training callback that works with any client backend."""
+
+    SUPPORTED_FORMATS = ("eps", "jpeg", "jpg", "pdf", "pgf", "png", "ps", "raw", "rgba", "svg", "svgz", "tif", "tiff")
+
+    def __init__(
+        self,
+        client: BaseClient,
+        model_name: str,
+        track_logs: list[str] | None = None,
+        monitor: str | None = None,
+        export: str = "png",
+        send_plot: bool = False,
+    ):
+        super().__init__()
+        if export not in self.SUPPORTED_FORMATS:
+            raise ValueError(f"Unsupported export format '{export}'. Supported: {self.SUPPORTED_FORMATS}")
+
+        if track_logs is None:
+            log.error("Provide at least 1 log type for sending update.")
+            sys.exit()
+        if not isinstance(track_logs, list):
+            log.error("'track_logs' must be a list, e.g. ['train_loss', 'val_loss']")
+            sys.exit()
+
+        if monitor is not None and monitor not in track_logs:
+            log.error(f"'monitor' value '{monitor}' not found in 'track_logs'")
+            sys.exit()
+        elif monitor is None:
+            log.warning("'monitor' not provided, will skip reporting Best Epoch")
+
+        self.client = client
+        self.model_name = model_name
+        self.track_logs = track_logs
+        self.monitor = monitor
+        self.export = export
+        self.send_plot = send_plot
+
+        if not client.is_connected:
+            _run_sync(client.connect())
+
+        self.training_logs: dict[str, list[float]] = {}
+        self.n_epochs = 0
+
+    def on_fit_start(self, trainer, pl_module):
+        self.client.send_message_sync(
+            f'Training on "{self.model_name}" started at {datetime.now().strftime("%Y-%m-%d %H:%M:%S")}'
+        )
+
+    def on_train_epoch_end(self, trainer, pl_module):
+        metrics = trainer.callback_metrics
+
+        for key in self.track_logs:
+            val = float(metrics[key])
+            self.training_logs.setdefault(key, []).append(val)
+
+        parts = [f"{key}: {metrics[key]:.4f}" for key in self.track_logs]
+        message = f"Epoch: {self.n_epochs}, {', '.join(parts)}"
+
+        url = "www.slack.com" if self.client.platform == "slack" else "www.telegram.org"
+        connected = _run_sync(network.check_connection_quick(url=url))
+        if connected:
+            self.client.send_message_sync(message)
+
+        self.n_epochs += 1
+
+    def on_fit_end(self, trainer, pl_module):
+        if self.monitor is not None:
+            for key, values in self.training_logs.items():
+                if self.monitor.lower() in key.lower():
+                    if "loss" in self.monitor.lower():
+                        best = int(np.argmin(values))
+                    else:
+                        best = int(np.argmax(values))
+                    message = f"Trained for {self.n_epochs} epochs. Best epoch was, Epoch {best}"
+                    break
+            else:
+                message = f"Trained for {self.n_epochs} epochs."
+        else:
+            message = f"Trained for {self.n_epochs} epochs. 'monitor' was not provided, skipped reporting Best Epoch"
+
+        self.client.send_message_sync(message)
+
+        if self.send_plot:
+            paths = plotting.generate_and_get_plots(self.model_name, self.export, self.training_logs)
+            for path in paths:
+                self.client.upload_image_sync(path, comment=f"{self.model_name} 📎")
+
+
+# ──────────────────────────────────────────────
+# Backward-compatible shims (deprecated)
+# ──────────────────────────────────────────────
+
+from slackker.core.slack import SlackClient
+from slackker.core.telegram import TelegramClient
+
+
+class SlackUpdate(LightningCallback):
+    """Deprecated: Use LightningCallback(SlackClient(...), ...) instead."""
+
     def __init__(self, token, channel, ModelName, TrackLogs=None, monitor=None, export="png", SendPlot=False, verbose=0):
+        warnings.warn(
+            "SlackUpdate is deprecated. Use LightningCallback(SlackClient(token, channel), ...) instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         if token is None:
-            colors.prRed('[slackker] ERROR: Please enter Valid Slack API Token.')
+            log.error("Please enter a valid Slack API Token.")
             return
 
-        server = checkker.check_internet(url="www.slack.com", verbose=verbose)
-        api = checkker.slack_connect(token=token, verbose=verbose)
+        client = SlackClient(token=token, channel=channel, verbose=verbose)
+        connected = _run_sync(client.connect())
+        if not connected:
+            log.error("Failed to connect to Slack.")
+            return
 
-        if server and api:
-            self.client = WebClient(token=token)
-            self.channel = channel
-            self.ModelName = ModelName
-            self.export = export
-            self.SendPlot = SendPlot
-            self.verbose = verbose
-            self.TrackLogs = TrackLogs
-            self.monitor = monitor
+        super().__init__(
+            client=client,
+            model_name=ModelName,
+            track_logs=TrackLogs,
+            monitor=monitor,
+            export=export,
+            send_plot=SendPlot,
+        )
 
-            if export is not None:
-                pass
-            else:
-                raise argparse.ArgumentTypeError("[slackker] ERROR: 'export' argument is missing (supported formats: eps, jpeg, jpg, pdf, pgf, png, ps, raw, rgba, svg, svgz, tif, tiff)")
+        # Expose old attribute names for backward compat
+        self.ModelName = ModelName
+        self.TrackLogs = TrackLogs
+        self.SendPlot = SendPlot
+        self.verbose = verbose
+        self._sdk_client = client._client
+        self.channel = channel
 
-            if TrackLogs is None:
-                colors.prRed("[slackker] ERROR: Provice at least 1 log type for sending update.")
-                sys.exit()
-            else:
-                if type(TrackLogs) is not list and TrackLogs is not None:
-                    colors.prRed("[slackker] ERROR: 'TrackLogs' is a list type of argument, add values in '[]'")
-                    sys.exit()
-                else:
-                    pass
 
-            if monitor is not None:
-                if monitor not in TrackLogs:
-                    colors.prRed("[slackker] ERROR: Couldn't find Argument 'monitor' value in 'TrackLogs' provided")
-                    sys.exit()
-                else:
-                    pass
-            else:
-                colors.prYellow("[slackker] WARNING: Argument 'monitor' not provided, will skip reporting Best Epoch")
+class TelegramUpdate(LightningCallback):
+    """Deprecated: Use LightningCallback(TelegramClient(...), ...) instead."""
 
-        self.training_logs = {}
-        self.n_epochs = 0
-
-    # Called when training starts
-    def on_fit_start(self, trainer, pl_module):
-        functions.Slack.report_stats(
-            client=self.client,
-            channel=self.channel,
-            text=f'Training on "{self.ModelName}" started at {datetime.now().strftime("%Y-%m-%d %H:%M:%S")}',
-            verbose=self.verbose)
-
-    # Called when every training epoch ends
-    def on_train_epoch_end(self, trainer, pl_module):
-        metrics = trainer.callback_metrics
-        logs = self.TrackLogs
-
-        custom_logs = {}
-        toPrint = []
-
-        [custom_logs.update({i:float(metrics[i])}) for i in logs]
-
-        [self.training_logs.setdefault(key, []).append(value) for key, value in custom_logs.items()]
-
-        [toPrint.append(f"{i}: {metrics[i]:.4f}") for i in logs]
-
-        message = f"Epoch: {self.n_epochs}, {', '.join(toPrint)}"
-
-        # Check internet before sending update on slacj
-        server = checkker.check_internet_epoch_end(url="www.slack.com")
-
-        # If internet working send message else skip sending message and continue training.
-        if server:
-            functions.Slack.report_stats(
-                client=self.client,
-                channel=self.channel,
-                text=message,
-                verbose=self.verbose)
-        else:
-            pass
-
-        self.n_epochs += 1
-
-    # Prepare and send report with graphs at the end of training.
-    def on_fit_end(self, trainer, pl_module):
-        if self.monitor is not None:
-            for key, value in self.training_logs.items():
-                if "loss" in self.monitor.lower():
-                    if self.monitor.lower() in key.lower():
-                        # print(f"Lowest loss value is {min(value)}")
-                        message = f"Trained for {self.n_epochs} epochs. Best epoch was, Epoch {np.argmin(value)}"
-                elif "acc" in self.monitor.lower():
-                    if self.monitor.lower() in key.lower():
-                        # print(f"Highest accuracy value is{max(value)}")
-                        message = f"Trained for {self.n_epochs} epochs. Best epoch was, Epoch {np.argmax(value)}"
-        else:
-            message = f"Trained for {self.n_epochs} epochs. Argument 'monitor' was not provided, skipped reporting Best Epoch"
-
-        functions.Slack.report_stats(
-            client=self.client,
-            channel=self.channel,
-            text=message,
-            verbose=self.verbose)
-
-        functions.Slack.lightning_plot_history(ModelName=self.ModelName,
-            export=self.export,
-            client=self.client,
-            channel=self.channel,
-            SendPlot=self.SendPlot,
-            training_logs=self.training_logs,
-            verbose=self.verbose)
-
-class TelegramUpdate(Callback):
-    """Custom Lightning callback that posts to Telegram while training a neural network"""
     def __init__(self, token, ModelName, TrackLogs=None, monitor=None, export="png", SendPlot=False, verbose=0):
+        warnings.warn(
+            "TelegramUpdate is deprecated. Use LightningCallback(TelegramClient(token), ...) instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         if token is None:
-            colors.prRed('[slackker] ERROR: Please enter Valid Telegram API Token.')
+            log.error("Please enter a valid Telegram API Token.")
             return
 
-        server = checkker.check_internet(url="www.telegram.org", verbose=verbose)
-        channel = checkker.get_telegram_chat_id(token=token, verbose=verbose)
+        client = TelegramClient(token=token, verbose=verbose)
+        connected = _run_sync(client.connect())
+        if not connected:
+            log.error("Failed to connect to Telegram.")
+            return
 
-        if server and channel:
-            self.token = token
-            self.channel = channel
-            self.ModelName = ModelName
-            self.export = export
-            self.SendPlot = SendPlot
-            self.verbose = verbose
-            self.TrackLogs = TrackLogs
-            self.monitor = monitor
+        super().__init__(
+            client=client,
+            model_name=ModelName,
+            track_logs=TrackLogs,
+            monitor=monitor,
+            export=export,
+            send_plot=SendPlot,
+        )
 
-            if export is not None:
-                pass
-            else:
-                raise argparse.ArgumentTypeError("[slackker] ERROR: 'export' argument is missing (supported formats: eps, jpeg, jpg, pdf, pgf, png, ps, raw, rgba, svg, svgz, tif, tiff)")
-
-            if TrackLogs is None:
-                colors.prRed("[slackker] ERROR: Provice at least 1 log type for sending update.")
-                sys.exit()
-            else:
-                if type(TrackLogs) is not list and TrackLogs is not None:
-                    colors.prRed("[slackker] ERROR: 'TrackLogs' is a list type of argument, add values in '[]'")
-                    sys.exit()
-                else:
-                    pass
-
-            if monitor is not None:
-                if monitor not in TrackLogs:
-                    colors.prRed("[slackker] ERROR: Couldn't find Argument 'monitor' value in 'TrackLogs' provided")
-                    sys.exit()
-                else:
-                    pass
-            else:
-                colors.prYellow("[slackker] WARNING: Argument 'monitor' not provided, will skip reporting Best Epoch")
-
-        self.training_logs = {}
-        self.n_epochs = 0
-
-    # Called when training starts
-    def on_fit_start(self, trainer, pl_module):
-        functions.Telegram.report_stats(
-            token=self.token,
-            channel=self.channel,
-            text=f'Training on "{self.ModelName}" started at {datetime.now().strftime("%Y-%m-%d %H:%M:%S")}',
-            verbose=self.verbose)
-
-    # Called when every training epoch ends
-    def on_train_epoch_end(self, trainer, pl_module):
-        metrics = trainer.callback_metrics
-        logs = self.TrackLogs
-
-        custom_logs = {}
-        toPrint = []
-
-        [custom_logs.update({i:float(metrics[i])}) for i in logs]
-
-        [self.training_logs.setdefault(key, []).append(value) for key, value in custom_logs.items()]
-
-        [toPrint.append(f"{i}: {metrics[i]:.4f}") for i in logs]
-
-        message = f"Epoch: {self.n_epochs}, {', '.join(toPrint)}"
-
-        # Check internet before sending update on slacj
-        server = checkker.check_internet_epoch_end(url="www.slack.com")
-
-        # If internet working send message else skip sending message and continue training.
-        if server:
-            functions.Telegram.report_stats(
-                token=self.token,
-                channel=self.channel,
-                text=message,
-                verbose=self.verbose)
-        else:
-            pass
-
-        self.n_epochs += 1
-
-    # Prepare and send report with graphs at the end of training.
-    def on_fit_end(self, trainer, pl_module):
-        if self.monitor is not None:
-            for key, value in self.training_logs.items():
-                if "loss" in self.monitor.lower():
-                    if self.monitor.lower() in key.lower():
-                        # print(f"Lowest loss value is {min(value)}")
-                        message = f"Trained for {self.n_epochs} epochs. Best epoch was, Epoch {np.argmin(value)}"
-                elif "acc" in self.monitor.lower():
-                    if self.monitor.lower() in key.lower():
-                        # print(f"Highest accuracy value is{max(value)}")
-                        message = f"Trained for {self.n_epochs} epochs. Best epoch was, Epoch {np.argmax(value)}"
-        else:
-            message = f"Trained for {self.n_epochs} epochs. Argument 'monitor' was not provided, skipped reporting Best Epoch"
-
-        functions.Telegram.report_stats(
-            token=self.token,
-            channel=self.channel,
-            text=message,
-            verbose=self.verbose)
-
-        functions.Telegram.lightning_plot_history(ModelName=self.ModelName,
-            export=self.export,
-            token=self.token,
-            channel=self.channel,
-            SendPlot=self.SendPlot,
-            training_logs=self.training_logs,
-            verbose=self.verbose)
+        # Expose old attribute names for backward compat
+        self.ModelName = ModelName
+        self.TrackLogs = TrackLogs
+        self.SendPlot = SendPlot
+        self.verbose = verbose
+        self.token = token
+        self.channel = client.chat_id

--- a/slackker/callbacks/simple.py
+++ b/slackker/callbacks/simple.py
@@ -1,0 +1,63 @@
+import time
+import os
+from inspect import stack
+from datetime import datetime
+from slackker.core.client import BaseClient, _run_sync
+from slackker.utils.logger import log
+
+
+class SimpleCallback:
+    """Notification callback that works with any client backend.
+
+    Provides a decorator (`notifier`) for automatic function reporting,
+    and `notify()` / `async_notify()` for manual notifications.
+    """
+
+    def __init__(self, client: BaseClient):
+        self.client = client
+        if not client.is_connected:
+            _run_sync(client.connect())
+
+    def notifier(self, function):
+        """Decorator to log function calls and send execution reports."""
+        def wrapper(*args, **kwargs):
+            if self.client.verbose > 0:
+                log.info(f"Calling {function.__name__} with args: {args}, kwargs: {kwargs}")
+
+            start_time = time.time()
+            result = function(*args, **kwargs)
+            execution_time = time.time() - start_time
+
+            script_name = os.path.basename(__import__(function.__module__).__file__)
+            base_msg = f"Function '{function.__name__}' from Script: '{script_name}' executed.\nExecution time: {execution_time:.3f} Seconds"
+
+            if result is not None:
+                if isinstance(result, tuple):
+                    message = f"{base_msg}\nReturned {len(result)} outputs:\n"
+                    for num, item in enumerate(result):
+                        message += f"Output {num}:\n{item}\n\n"
+                else:
+                    message = f"{base_msg}\nReturned output: {result}"
+            else:
+                message = f"{base_msg}\nReturned output: None"
+
+            self.client.send_message_sync(message)
+            return result
+        return wrapper
+
+    async def async_notify(self, event: str | None = None, attachment: str | None = None, **kwargs):
+        """Async notification method."""
+        script = stack()[1].filename
+        text = f"Notification: {event or os.path.basename(script)} at {datetime.now().strftime('%d-%m-%Y %H:%M:%S')}"
+
+        for key, value in kwargs.items():
+            text += f"\n{key}: {value}"
+
+        if attachment:
+            await self.client.upload_file(attachment, comment=text)
+        else:
+            await self.client.send_message(text)
+
+    def notify(self, event: str | None = None, attachment: str | None = None, **kwargs):
+        """Sync notification method."""
+        _run_sync(self.async_notify(event, attachment, **kwargs))

--- a/slackker/core/__init__.py
+++ b/slackker/core/__init__.py
@@ -1,0 +1,5 @@
+from slackker.core.client import BaseClient
+from slackker.core.slack import SlackClient
+from slackker.core.telegram import TelegramClient
+
+__all__ = ["BaseClient", "SlackClient", "TelegramClient"]

--- a/slackker/core/client.py
+++ b/slackker/core/client.py
@@ -1,0 +1,66 @@
+import asyncio
+from abc import ABC, abstractmethod
+
+
+def _run_sync(coro):
+    """Run an async coroutine synchronously, handling already-running event loops (e.g. Jupyter)."""
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = None
+
+    if loop and loop.is_running():
+        import nest_asyncio
+        nest_asyncio.apply()
+        return loop.run_until_complete(coro)
+    else:
+        return asyncio.run(coro)
+
+
+class BaseClient(ABC):
+    """Abstract base class for all client backends (Slack, Telegram, etc.)."""
+
+    def __init__(self, verbose: int = 0):
+        self._verbose = verbose
+
+    @property
+    def verbose(self) -> int:
+        return self._verbose
+
+    @property
+    @abstractmethod
+    def platform(self) -> str:
+        """Return the platform name, e.g. 'slack' or 'telegram'."""
+        ...
+
+    @property
+    @abstractmethod
+    def is_connected(self) -> bool:
+        """Return True if the client has successfully connected (token verified, chat_id known, etc.)."""
+        ...
+
+    @abstractmethod
+    async def send_message(self, text: str) -> None:
+        """Send a text message to the configured channel."""
+        ...
+
+    @abstractmethod
+    async def upload_file(self, filepath: str, comment: str | None = None) -> None:
+        """Upload a file to the configured channel."""
+        ...
+
+    @abstractmethod
+    async def upload_image(self, filepath: str, comment: str | None = None) -> None:
+        """Upload an image to the configured channel."""
+        ...
+
+    # --- Sync convenience wrappers ---
+
+    def send_message_sync(self, text: str) -> None:
+        _run_sync(self.send_message(text))
+
+    def upload_file_sync(self, filepath: str, comment: str | None = None) -> None:
+        _run_sync(self.upload_file(filepath, comment))
+
+    def upload_image_sync(self, filepath: str, comment: str | None = None) -> None:
+        _run_sync(self.upload_image(filepath, comment))

--- a/slackker/core/slack.py
+++ b/slackker/core/slack.py
@@ -1,0 +1,69 @@
+import os
+from slack_sdk.web.async_client import AsyncWebClient
+from slack_sdk.errors import SlackApiError
+from slackker.core.client import BaseClient
+from slackker.utils.logger import log
+from slackker.utils import network
+
+
+class SlackClient(BaseClient):
+    """Slack client backend using the async Slack SDK."""
+
+    def __init__(self, token: str, channel: str, verbose: int = 0):
+        super().__init__(verbose=verbose)
+        if not token:
+            raise ValueError("Slack API token is required.")
+        self._token = token
+        self._channel = channel
+        self._client = AsyncWebClient(token=token)
+        self._connected = False
+
+    @property
+    def platform(self) -> str:
+        return "slack"
+
+    @property
+    def channel(self) -> str:
+        return self._channel
+
+    @property
+    def is_connected(self) -> bool:
+        return self._connected
+
+    async def connect(self) -> bool:
+        """Verify server connectivity and API token. Returns True on success."""
+        server = await network.check_connection(url="www.slack.com", verbose=self._verbose)
+        api = await network.verify_slack_token(token=self._token, verbose=self._verbose)
+        self._connected = server and api
+        return self._connected
+
+    async def send_message(self, text: str) -> None:
+        try:
+            await self._client.chat_postMessage(channel=self._channel, text=text)
+            if self._verbose >= 1:
+                log.info(f"Posted update on {self._channel} channel")
+        except SlackApiError as e:
+            log.error(f"Error posting update: {e}")
+
+    async def upload_file(self, filepath: str, comment: str | None = None) -> None:
+        try:
+            if not os.path.isfile(filepath):
+                log.error(f"Invalid file path: {filepath}")
+                return
+            initial_comment = comment or "Attachment 📎"
+            await self._client.files_upload_v2(
+                channel=self._channel,
+                file=filepath,
+                initial_comment=initial_comment,
+            )
+            if self._verbose >= 1:
+                log.debug(f"Uploaded attachment on {self._channel} channel")
+        except SlackApiError as e:
+            log.error(f"Error uploading attachment: {e}")
+
+    async def upload_image(self, filepath: str, comment: str | None = None) -> None:
+        # Slack handles images the same way as files
+        await self.upload_file(filepath, comment)
+
+    async def close(self) -> None:
+        await self._client.close()

--- a/slackker/core/telegram.py
+++ b/slackker/core/telegram.py
@@ -1,0 +1,110 @@
+import os
+import httpx
+from slackker.core.client import BaseClient
+from slackker.utils.logger import log
+from slackker.utils import network
+
+
+class TelegramClient(BaseClient):
+    """Telegram client backend using httpx async client."""
+
+    BASE_URL = "https://api.telegram.org/bot{token}"
+
+    def __init__(self, token: str, chat_id: str | None = None, verbose: int = 0):
+        super().__init__(verbose=verbose)
+        if not token:
+            raise ValueError("Telegram API token is required.")
+        self._token = token
+        self._chat_id = chat_id
+        self._base_url = self.BASE_URL.format(token=token)
+
+    @property
+    def platform(self) -> str:
+        return "telegram"
+
+    @property
+    def is_connected(self) -> bool:
+        return self._chat_id is not None
+
+    @property
+    def chat_id(self) -> str | None:
+        return self._chat_id
+
+    async def connect(self) -> bool:
+        """Verify server connectivity and discover chat_id if not provided."""
+        server = await network.check_connection(url="www.telegram.org", verbose=self._verbose)
+        if not server:
+            return False
+
+        if not self._chat_id:
+            self._chat_id = await network.get_telegram_chat_id(
+                token=self._token, verbose=self._verbose
+            )
+
+        return self._chat_id is not None
+
+    async def send_message(self, text: str) -> None:
+        if not self._chat_id:
+            log.error("chat_id is not set. Call `await client.connect()` before sending messages.")
+            return
+        url = f"{self._base_url}/sendMessage"
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.post(url, params={"chat_id": self._chat_id, "text": text})
+                response.raise_for_status()
+            if self._verbose >= 1:
+                log.debug("Posted update on Telegram")
+        except httpx.HTTPStatusError as e:
+            log.error(f"Telegram API error {e.response.status_code}: {e.response.text}")
+        except Exception as e:
+            log.error(f"Error posting update: {e}")
+
+    async def upload_file(self, filepath: str, comment: str | None = None) -> None:
+        if not self._chat_id:
+            log.error("chat_id is not set. Call `await client.connect()` before uploading files.")
+            return
+        url = f"{self._base_url}/sendDocument"
+        try:
+            if not os.path.isfile(filepath):
+                log.error(f"Invalid file path: {filepath}")
+                return
+            caption = comment or "Attachment 📎"
+            async with httpx.AsyncClient() as client:
+                with open(filepath, "rb") as f:
+                    response = await client.post(
+                        url,
+                        params={"chat_id": self._chat_id, "caption": caption},
+                        files={"document": f},
+                    )
+                    response.raise_for_status()
+            if self._verbose >= 1:
+                log.debug("Uploaded attachment on Telegram")
+        except httpx.HTTPStatusError as e:
+            log.error(f"Telegram API error {e.response.status_code}: {e.response.text}")
+        except Exception as e:
+            log.error(f"Error uploading file: {e}")
+
+    async def upload_image(self, filepath: str, comment: str | None = None) -> None:
+        if not self._chat_id:
+            log.error("chat_id is not set. Call `await client.connect()` before uploading images.")
+            return
+        url = f"{self._base_url}/sendPhoto"
+        try:
+            if not os.path.isfile(filepath):
+                log.error(f"Invalid file path: {filepath}")
+                return
+            caption = comment or "Attachment 📎"
+            async with httpx.AsyncClient() as client:
+                with open(filepath, "rb") as f:
+                    response = await client.post(
+                        url,
+                        params={"chat_id": self._chat_id, "caption": caption},
+                        files={"photo": f},
+                    )
+                    response.raise_for_status()
+            if self._verbose >= 1:
+                log.debug("Uploaded image on Telegram")
+        except httpx.HTTPStatusError as e:
+            log.error(f"Telegram API error {e.response.status_code}: {e.response.text}")
+        except Exception as e:
+            log.error(f"Error uploading image: {e}")

--- a/slackker/utils/ccolors.py
+++ b/slackker/utils/ccolors.py
@@ -1,3 +1,11 @@
+import warnings
+
+warnings.warn(
+    "slackker.utils.ccolors is deprecated. Use slackker.utils.logger instead.",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
 class colors:
 	# Assign colors to logging statements
 	def prRed(sent):

--- a/slackker/utils/checkker.py
+++ b/slackker/utils/checkker.py
@@ -1,90 +1,31 @@
-import time
-import requests
-import http.client as httplib
-from slack_sdk import WebClient
-from datetime import datetime
-from slackker.utils.ccolors import colors
+"""Deprecated: Use slackker.utils.network instead."""
 
-# Check whether server is still alive.
+import warnings
+from slackker.utils.network import (
+    check_connection_sync,
+    check_connection_quick_sync,
+    verify_slack_token_sync,
+    get_telegram_chat_id_sync,
+)
+
+warnings.warn(
+    "slackker.utils.checkker is deprecated. Use slackker.utils.network instead.",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
+
 def check_internet(url, verbose=2):
-    counter=1
-    status=False
-    sleepinsec=60
+    return check_connection_sync(url=url, retries=0, delay=60, verbose=verbose)
 
-    while status is False:
-        conn = httplib.HTTPConnection(url, timeout=5)
-        try:
-            conn.request("HEAD", "/")
-            conn.close()
-            status=True
-            if verbose >= 2:
-                colors.prCyan(f"[slackker] DEBUG: {datetime.now().strftime('%d-%m-%Y %H:%M:%S')} Connection to '{url}' server successful!")
-        except Exception:
-            status=False
-            colors.prYellow(f"[slackker] WARNING:: {datetime.now().strftime('%d-%m-%Y %H:%M:%S')} Connection to '{url}' server failed. Please check your internet. Trying again in 60 sec..[attempt {counter}]")
-            time.sleep(sleepinsec)
-            counter=counter+1
 
-    if counter>1:
-        if verbose>=2:
-            colors.prCyan(f"[slackker] DEBUG: {datetime.now().strftime('%d-%m-%Y %H:%M')} re-established connection to '{url}' server after {counter} attempts.")
-
-    return status
-
-# Check whether server is still alive at the end of epoch if not skip the training. 
 def check_internet_epoch_end(url):
-    counter=1
-    status=False
-    sleepinsec=10
-
-    while status is False and counter <= 3:
-        conn = httplib.HTTPConnection(url, timeout=5)
-        try:
-            conn.request("HEAD", "/")
-            conn.close()
-            status=True
-        except Exception:
-            status=False
-            colors.prYellow(f"[slackker] WARNING: {datetime.now().strftime('%d-%m-%Y %H:%M:%S')} Connection to '{url}' server failed. Trying again in 10 sec..[attempt {counter}]")
-            time.sleep(sleepinsec)
-            counter=counter+1
-                
-    if counter <= 3 and counter > 1:
-        colors.prCyan(f"[slackker] DEBUG: {datetime.now().strftime('%d-%m-%Y %H:%M:%S')} re-established connection to '{url}' server after {counter} attempts.")
-    elif counter > 3:
-        colors.prYellow(f'[slackker] WARNING: Skipping report update due to connection failure. {counter} attempts made before skipping')
-
-    return status
+    return check_connection_quick_sync(url=url, max_retries=3, delay=10, verbose=1)
 
 
 def slack_connect(token, verbose=2):
-    status = False
+    return verify_slack_token_sync(token=token, verbose=verbose)
 
-    try:
-        client = WebClient(token=token)
-        api_response = client.api_test()
-        status = True
-        if verbose >= 2:
-            colors.prCyan(f"[slackker] DEBUG: Connection to slack API successful! {api_response}")
-    except Exception as e:
-        status = False
-        colors.prRed(f"[slackker] ERROR: Invalid slack API token: {e}")
-
-    return status
 
 def get_telegram_chat_id(token, verbose=2):
-    chat_id = False
-    url = f"https://api.telegram.org/bot{token}/getUpdates"
-
-    try:
-        firstMsg = requests.get(url).json()
-        chat_id = str(firstMsg["result"][0]["message"]["chat"]["id"])
-        if verbose >= 2:
-            colors.prCyan(f"[slackker] DEBUG: Connection to telegram API successful!")
-            colors.prCyan(f"[slackker] DEBUG: Found chat with 'chat_id'={chat_id}")
-    except Exception as e:
-        chat_id = False
-        colors.prRed(f"[slackker] ERROR: Could not connect to Telegram API: {e}")
-        colors.prYellow(f"[slackker] SUGGESTION: Please send 'Hello' once to your bot to make it discoverable to slackker")
-
-    return chat_id
+    return get_telegram_chat_id_sync(token=token, verbose=verbose)

--- a/slackker/utils/functions.py
+++ b/slackker/utils/functions.py
@@ -1,190 +1,126 @@
-import requests
-import itertools
+"""Deprecated: Use slackker.core and slackker.utils.plotting instead."""
+
+import warnings
 import os
-import matplotlib.pyplot as plt
-from slack_sdk.errors import SlackApiError
-from slackker.utils.ccolors import colors
+from slackker.utils.logger import log
+from slackker.utils.plotting import generate_plot
+
+warnings.warn(
+    "slackker.utils.functions is deprecated. Use slackker.core client classes and slackker.utils.plotting instead.",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
 
 class Plotter:
+    """Deprecated: Use slackker.utils.plotting and client.upload_file() instead."""
+
     @staticmethod
     def slack_file_upload(name, client, channel, filepath, initial_comment=None, verbose=1):
-        """Upload generated attachments"""
+        from slack_sdk.errors import SlackApiError
         try:
-            comment = initial_comment if initial_comment is not None else f"{name} :paperclip:"
-            # Call the chat.postMessage method using the WebClient
-            response = client.files_upload_v2(channel=channel,
-            file = filepath,
-            initial_comment=comment)
-            if verbose>=1:
-                colors.prCyan(f"[slackker] DEBUG: Uploaded attachment on {channel} channel")
-
+            comment = initial_comment if initial_comment is not None else f"{name} 📎"
+            client.files_upload_v2(channel=channel, file=filepath, initial_comment=comment)
+            if verbose >= 1:
+                log.debug(f"Uploaded attachment on {channel} channel")
         except SlackApiError as e:
-            colors.prRed(f"[slackker] ERROR: Error uploading attachment: {e}")
-    
+            log.error(f"Error uploading attachment: {e}")
+
     @staticmethod
     def telegram_img_upload(name, token, channel, image, verbose=1):
-        # apiURL for send image
-        apiURL = f'https://api.telegram.org/bot{token}/sendPhoto'
-
+        import requests
+        url = f"https://api.telegram.org/bot{token}/sendPhoto"
         try:
-            # Call the requests.post method using API request
-            response = requests.post(apiURL, params={'chat_id': channel, 'caption': f"{name} \U0001F4CE"}, files={'photo': image})
-            if verbose>=1:
-                colors.prCyan("[slackker] DEBUG: Uploaded attachment on Telegram")
-
+            requests.post(url, params={"chat_id": channel, "caption": f"{name} 📎"}, files={"photo": image})
+            if verbose >= 1:
+                log.debug("Uploaded attachment on Telegram")
         except Exception as e:
-            colors.prRed(f"[slackker] ERROR: Error uploading attachment: {e}")
-    
+            log.error(f"Error uploading attachment: {e}")
+
     @staticmethod
     def telegram_file_upload(name, token, channel, file, caption=None, verbose=1):
-        # apiURL for send file
-        apiURL = f'https://api.telegram.org/bot{token}/sendDocument'
-
+        import requests
+        url = f"https://api.telegram.org/bot{token}/sendDocument"
         try:
-            tg_caption = caption if caption is not None else f"{name} \U0001F4CE"
-            # Call the requests.post method using API request
-            response = requests.post(apiURL, params={'chat_id': channel, 'caption': tg_caption}, files={'document': file})
-            if verbose>=1:
-                colors.prCyan("[slackker] DEBUG: Uploaded attachment on Telegram")
-
+            tg_caption = caption if caption is not None else f"{name} 📎"
+            requests.post(url, params={"chat_id": channel, "caption": tg_caption}, files={"document": file})
+            if verbose >= 1:
+                log.debug("Uploaded attachment on Telegram")
         except Exception as e:
-            colors.prRed(f"[slackker] ERROR: Error uploading attachment: {e}")
+            log.error(f"Error uploading attachment: {e}")
 
     @staticmethod
     def plot_and_upload(platform, ModelName, export, client, channel, SendPlot, logs, metric, verbose=1):
-        try:
-            # Make sure training has began
-            if len(logs) == 0:
-                colors.prRed('[slackker] ERROR: Loss is missing from training history')
-                return
-
-            # As loss always exists
-            k = str(list(logs.keys())[0])
-            epochs = range(0, len(logs[k]))
-
-            # color choices list
-            clrs = ['b-', 'g-', 'r-', 'c-', 'm-', 'y-', 'k-', 'orange', 'darkviolet', 'fuchsia']
-
-            # seperate color iterator for loss and acc graphs
-            ls, acc = itertools.tee(clrs, 2) # create as many as needed
-
-            path = f'{ModelName}_{metric}.{export}'
-
-            # Plotting
-            plt.figure(1, figsize=(15,8))
-
-            for key, value in logs.items():
-                if metric in key.lower():
-                    plt.plot(epochs, logs[key], next(ls) if metric == "loss" else next(acc), lw=2.5, label=f'{key}: {logs[key][-1]:.4f}')
+        path = generate_plot(ModelName, export, logs, metric)
+        if path and SendPlot:
+            try:
+                if platform == "slack":
+                    Plotter.slack_file_upload(name=f"{ModelName}_{metric}", client=client, channel=channel, filepath=path, verbose=verbose)
                 else:
-                    pass
-            plt.title(f'{ModelName}_{metric}_Graph', fontsize=20)
-            plt.xlabel('Epochs', fontsize=15)
-            plt.ylabel(f'{metric}', fontsize=15)
-            plt.legend(fontsize=12)
-            plt.grid(True)
-            plt.savefig(path)
-            plt.close()
+                    Plotter.telegram_img_upload(name=f"{ModelName}_{metric}", token=client, channel=channel, image=open(path, "rb"), verbose=verbose)
+            except Exception as e:
+                log.error(f"Invalid Argument: {e}")
+        elif not SendPlot:
+            log.warning("Skipping graph upload as SendPlot == False")
 
-            if SendPlot:
-                try:
-                    if platform == 'slack':
-                        Plotter.slack_file_upload(name = f'{ModelName}_{metric}', client=client, channel=channel, filepath=path, verbose=verbose)
-                    else:
-                        Plotter.telegram_img_upload(name = f'{ModelName}_{metric}', token=client, channel=channel, image=open(path, 'rb'), verbose=verbose)
-                except Exception as e:
-                    colors.prRed(f"[slackker] ERROR: Invalid Argument: {e}")
-            else:
-                colors.prYellow("[slackker] WARNING: Skipping graph upload as SendPlot == False ")
-        except Exception as e:
-            colors.prRed(f'[slackker] ERROR: Plotting Generation Failed: {e}')
 
 class Slack:
+    """Deprecated: Use slackker.core.SlackClient instead."""
+
     @staticmethod
     def report_stats(client, channel, text, attachment=None, verbose=1):
-        """Report training stats"""
+        from slack_sdk.errors import SlackApiError
         try:
             if attachment:
                 if not os.path.isfile(attachment):
-                    colors.prRed(f"[slackker] ERROR: Invalid attachment path: {attachment}")
+                    log.error(f"Invalid attachment path: {attachment}")
                     return
                 Plotter.slack_file_upload(
-                    name="Attachment",
-                    client=client,
-                    channel=channel,
-                    filepath=attachment,
-                    initial_comment=text,
-                    verbose=verbose
+                    name="Attachment", client=client, channel=channel, filepath=attachment, initial_comment=text, verbose=verbose
                 )
             else:
-                # Call the chat.postMessage method using the WebClient
-                client.chat_postMessage(
-                    channel=channel,
-                    text=text
-                )
-                if verbose>=1:
-                    colors.prCyan(f"[slackker] Posted update on {channel} channel")
-
+                client.chat_postMessage(channel=channel, text=text)
+                if verbose >= 1:
+                    log.info(f"Posted update on {channel} channel")
         except SlackApiError as e:
-            colors.prRed(f"[slackker] ERROR: Error posting update: {e}")
+            log.error(f"Error posting update: {e}")
 
     @staticmethod
     def keras_plot_history(ModelName, export, client, channel, SendPlot, training_logs, verbose=1):
-        #plot loss
-        Plotter.plot_and_upload(platform='slack', ModelName=ModelName, export=export, client=client, channel=channel, SendPlot=SendPlot, logs=training_logs, metric="loss", verbose=verbose)
-
-        #plot accuracy
-        Plotter.plot_and_upload(platform='slack', ModelName=ModelName, export=export, client=client, channel=channel, SendPlot=SendPlot, logs=training_logs, metric="acc", verbose=verbose)
+        Plotter.plot_and_upload(platform="slack", ModelName=ModelName, export=export, client=client, channel=channel, SendPlot=SendPlot, logs=training_logs, metric="loss", verbose=verbose)
+        Plotter.plot_and_upload(platform="slack", ModelName=ModelName, export=export, client=client, channel=channel, SendPlot=SendPlot, logs=training_logs, metric="acc", verbose=verbose)
 
     @staticmethod
     def lightning_plot_history(ModelName, export, client, channel, SendPlot, training_logs, verbose=1):
-        #plot loss
-        Plotter.plot_and_upload(platform='slack', ModelName=ModelName, export=export, client=client, channel=channel, SendPlot=SendPlot, logs=training_logs, metric="loss", verbose=verbose)
+        Slack.keras_plot_history(ModelName, export, client, channel, SendPlot, training_logs, verbose)
 
-        #plot accuracy
-        Plotter.plot_and_upload(platform='slack', ModelName=ModelName, export=export, client=client, channel=channel, SendPlot=SendPlot, logs=training_logs, metric="acc", verbose=verbose)
 
 class Telegram:
+    """Deprecated: Use slackker.core.TelegramClient instead."""
+
     @staticmethod
     def report_stats(token, channel, text, attachment=None, verbose=1):
-        # apiURL for send message
-        apiURL = f'https://api.telegram.org/bot{token}/sendMessage'
-
+        import requests
+        url = f"https://api.telegram.org/bot{token}/sendMessage"
         try:
             if attachment:
                 if not os.path.isfile(attachment):
-                    colors.prRed(f"[slackker] ERROR: Invalid attachment path: {attachment}")
+                    log.error(f"Invalid attachment path: {attachment}")
                     return
-                with open(attachment, 'rb') as uploaded_file:
-                    Plotter.telegram_file_upload(
-                        name="Attachment",
-                        token=token,
-                        channel=channel,
-                        file=uploaded_file,
-                        caption=text,
-                        verbose=verbose
-                    )
+                with open(attachment, "rb") as f:
+                    Plotter.telegram_file_upload(name="Attachment", token=token, channel=channel, file=f, caption=text, verbose=verbose)
             else:
-                # Call the requests.post method using API request
-                requests.post(apiURL, params={'chat_id': channel, 'text': text})
-                if verbose>=1:
-                    colors.prCyan("[slackker] DEBUG: Posted update on Telegram")
-
+                requests.post(url, params={"chat_id": channel, "text": text})
+                if verbose >= 1:
+                    log.debug("Posted update on Telegram")
         except Exception as e:
-            colors.prRed(f"[slackker] ERROR: Error posting update: {e}")
+            log.error(f"Error posting update: {e}")
 
     @staticmethod
     def keras_plot_history(ModelName, export, token, channel, SendPlot, training_logs, verbose=1):
-        #plot loss
-        Plotter.plot_and_upload(platform='telegram', ModelName=ModelName, export=export, client=token, channel=channel, SendPlot=SendPlot, logs=training_logs, metric="loss", verbose=verbose)
-
-        #plot accuracy
-        Plotter.plot_and_upload(platform='telegram', ModelName=ModelName, export=export, client=token, channel=channel, SendPlot=SendPlot, logs=training_logs, metric="acc", verbose=verbose)
+        Plotter.plot_and_upload(platform="telegram", ModelName=ModelName, export=export, client=token, channel=channel, SendPlot=SendPlot, logs=training_logs, metric="loss", verbose=verbose)
+        Plotter.plot_and_upload(platform="telegram", ModelName=ModelName, export=export, client=token, channel=channel, SendPlot=SendPlot, logs=training_logs, metric="acc", verbose=verbose)
 
     @staticmethod
     def lightning_plot_history(ModelName, export, token, channel, SendPlot, training_logs, verbose=1):
-        #plot loss
-        Plotter.plot_and_upload(platform='telegram', ModelName=ModelName, export=export, client=token, channel=channel, SendPlot=SendPlot, logs=training_logs, metric="loss", verbose=verbose)
-
-        #plot accuracy
-        Plotter.plot_and_upload(platform='telegram', ModelName=ModelName, export=export, client=token, channel=channel, SendPlot=SendPlot, logs=training_logs, metric="acc", verbose=verbose)
+        Telegram.keras_plot_history(ModelName, export, token, channel, SendPlot, training_logs, verbose)

--- a/slackker/utils/logger.py
+++ b/slackker/utils/logger.py
@@ -1,0 +1,16 @@
+import sys
+from loguru import logger
+
+# Remove default handler
+logger.remove()
+
+# Add slackker-prefixed handler
+logger.add(
+    sys.stderr,
+    format="<level>[slackker] {level}: {message}</level>",
+    level="DEBUG",
+    filter="slackker",
+)
+
+# Expose a module-level logger bound to slackker namespace
+log = logger.bind(name="slackker")

--- a/slackker/utils/network.py
+++ b/slackker/utils/network.py
@@ -1,0 +1,100 @@
+import asyncio
+import httpx
+from slack_sdk.web.async_client import AsyncWebClient
+from slackker.utils.logger import log
+
+
+def _run_sync(coro):
+    """Run an async coroutine synchronously, handling already-running event loops (e.g. Jupyter)."""
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = None
+
+    if loop and loop.is_running():
+        import nest_asyncio
+        nest_asyncio.apply()
+        return loop.run_until_complete(coro)
+    else:
+        return asyncio.run(coro)
+
+
+async def check_connection(url: str, retries: int = 0, delay: float = 60, verbose: int = 2) -> bool:
+    """Check if a server is reachable. Retries indefinitely if retries=0, else up to `retries` times."""
+    attempt = 0
+    async with httpx.AsyncClient() as client:
+        while True:
+            attempt += 1
+            try:
+                resp = await client.head(f"https://{url}", timeout=5)
+                if verbose >= 2:
+                    log.debug(f"Connection to '{url}' server successful!")
+                return True
+            except (httpx.RequestError, httpx.HTTPStatusError):
+                if retries > 0 and attempt >= retries:
+                    if verbose >= 1:
+                        log.warning(
+                            f"Connection to '{url}' server failed after {attempt} attempts."
+                        )
+                    return False
+                if verbose >= 1:
+                    log.warning(
+                        f"Connection to '{url}' server failed. "
+                        f"Trying again in {delay}s.. [attempt {attempt}]"
+                    )
+                await asyncio.sleep(delay)
+
+
+async def check_connection_quick(url: str, max_retries: int = 3, delay: float = 10, verbose: int = 1) -> bool:
+    """Quick connectivity check with limited retries (for use during training epochs)."""
+    return await check_connection(url=url, retries=max_retries, delay=delay, verbose=verbose)
+
+
+async def verify_slack_token(token: str, verbose: int = 2) -> bool:
+    """Verify a Slack API token by calling api.test."""
+    try:
+        client = AsyncWebClient(token=token)
+        response = await client.api_test()
+        await client.close()
+        if verbose >= 2:
+            log.debug(f"Connection to Slack API successful! {response}")
+        return True
+    except Exception as e:
+        log.error(f"Invalid Slack API token: {e}")
+        return False
+
+
+async def get_telegram_chat_id(token: str, verbose: int = 2) -> str | None:
+    """Retrieve the chat_id from the first message sent to the Telegram bot."""
+    url = f"https://api.telegram.org/bot{token}/getUpdates"
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(url)
+            data = resp.json()
+            chat_id = str(data["result"][0]["message"]["chat"]["id"])
+            if verbose >= 2:
+                log.debug("Connection to Telegram API successful!")
+                log.debug(f"Found chat with 'chat_id'={chat_id}")
+            return chat_id
+    except Exception as e:
+        log.error(f"Could not connect to Telegram API: {e}")
+        log.warning("Please send 'Hello' once to your bot to make it discoverable to slackker")
+        return None
+
+
+# --- Sync wrappers ---
+
+def check_connection_sync(url: str, retries: int = 0, delay: float = 60, verbose: int = 2) -> bool:
+    return _run_sync(check_connection(url, retries, delay, verbose))
+
+
+def check_connection_quick_sync(url: str, max_retries: int = 3, delay: float = 10, verbose: int = 1) -> bool:
+    return _run_sync(check_connection_quick(url, max_retries, delay, verbose))
+
+
+def verify_slack_token_sync(token: str, verbose: int = 2) -> bool:
+    return _run_sync(verify_slack_token(token, verbose))
+
+
+def get_telegram_chat_id_sync(token: str, verbose: int = 2) -> str | None:
+    return _run_sync(get_telegram_chat_id(token, verbose))

--- a/slackker/utils/plotting.py
+++ b/slackker/utils/plotting.py
@@ -1,0 +1,50 @@
+import os
+import itertools
+import matplotlib.pyplot as plt
+from slackker.utils.logger import log
+
+
+def generate_plot(model_name: str, export: str, logs: dict, metric: str) -> str | None:
+    """Generate a training metric plot and save to disk. Returns the file path, or None on failure."""
+    try:
+        if not logs:
+            log.error("Loss is missing from training history")
+            return None
+
+        first_key = next(iter(logs))
+        epochs = range(len(logs[first_key]))
+
+        color_cycle = ['b-', 'g-', 'r-', 'c-', 'm-', 'y-', 'k-', 'orange', 'darkviolet', 'fuchsia']
+        colors_iter = iter(color_cycle)
+
+        path = f"{model_name}_{metric}.{export}"
+
+        plt.figure(figsize=(15, 8))
+        for key, values in logs.items():
+            if metric in key.lower():
+                plt.plot(epochs, values, next(colors_iter), lw=2.5, label=f"{key}: {values[-1]:.4f}")
+        plt.title(f"{model_name}_{metric}_Graph", fontsize=20)
+        plt.xlabel("Epochs", fontsize=15)
+        plt.ylabel(metric, fontsize=15)
+        plt.legend(fontsize=12)
+        plt.grid(True)
+        plt.savefig(path)
+        plt.close()
+
+        return path
+    except Exception as e:
+        log.error(f"Plot generation failed: {e}")
+        return None
+
+
+def generate_and_get_plots(model_name: str, export: str, training_logs: dict, metrics: list[str] | None = None) -> list[str]:
+    """Generate plots for specified metrics (default: loss + acc). Returns list of file paths."""
+    if metrics is None:
+        metrics = ["loss", "acc"]
+
+    paths = []
+    for metric in metrics:
+        path = generate_plot(model_name, export, training_logs, metric)
+        if path:
+            paths.append(path)
+    return paths

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,678 +1,399 @@
 """
-Comprehensive tests for slackker.callbacks.basic module
-Tests cover SlackUpdate and TelegramUpdate classes with notifier decorator and notify method
+Comprehensive tests for slackker.callbacks.simple and slackker.callbacks.basic modules.
+Tests cover SimpleCallback and backward-compatible Update/SlackUpdate/TelegramUpdate shims.
 """
 
 import pytest
-from unittest.mock import Mock, MagicMock, patch, call
-from datetime import datetime
-from slackker.callbacks.basic import SlackUpdate, TelegramUpdate
+import warnings
+from unittest.mock import AsyncMock, MagicMock, patch
+from slackker.callbacks.simple import SimpleCallback
+from slackker.callbacks.basic import Update, SlackUpdate, TelegramUpdate
+from slackker.core.client import BaseClient
 
 
-class TestSlackUpdateInitialization:
-    """Test SlackUpdate class initialization"""
-    
-    @patch('slackker.callbacks.basic.checkker.check_internet')
-    @patch('slackker.callbacks.basic.checkker.slack_connect')
-    @patch('slackker.callbacks.basic.WebClient')
-    def test_slack_update_init_success(self, mock_webclient, mock_slack_connect, mock_check_internet):
-        """Test successful SlackUpdate initialization"""
-        mock_check_internet.return_value = True
-        mock_slack_connect.return_value = True
-        
-        slackker = SlackUpdate(token="test_token", channel="C123456", verbose=0)
-        
-        assert hasattr(slackker, 'client')
-        assert slackker.channel == "C123456"
-        assert slackker.verbose == 0
-        mock_webclient.assert_called_once_with(token="test_token")
-    
-    @patch('slackker.callbacks.basic.colors.prRed')
-    def test_slack_update_init_no_token(self, mock_print_red):
-        """Test SlackUpdate initialization with None token"""
-        slackker = SlackUpdate(token=None, channel="C123456")
-        mock_print_red.assert_called_once()
-    
-    @patch('slackker.callbacks.basic.checkker.check_internet')
-    @patch('slackker.callbacks.basic.checkker.slack_connect')
-    def test_slack_update_init_no_internet(self, mock_slack_connect, mock_check_internet):
-        """Test SlackUpdate initialization without internet"""
-        mock_check_internet.return_value = False
-        mock_slack_connect.return_value = True
-        
-        slackker = SlackUpdate(token="test_token", channel="C123456")
-        mock_check_internet.assert_called_once()
-    
-    @patch('slackker.callbacks.basic.checkker.check_internet')
-    @patch('slackker.callbacks.basic.checkker.slack_connect')
-    def test_slack_update_init_invalid_api(self, mock_slack_connect, mock_check_internet):
-        """Test SlackUpdate initialization with invalid Slack API"""
-        mock_check_internet.return_value = True
-        mock_slack_connect.return_value = False
-        
-        slackker = SlackUpdate(token="invalid_token", channel="C123456")
-        mock_slack_connect.assert_called_once()
+# ── Fixtures ──────────────────────────────────────────────────
+
+class MockClient(BaseClient):
+    """Concrete test client that records calls."""
+
+    def __init__(self, verbose=0):
+        super().__init__(verbose=verbose)
+        self.messages = []
+        self.uploaded_files = []
+        self.uploaded_images = []
+
+    @property
+    def platform(self):
+        return "mock"
+
+    @property
+    def is_connected(self):
+        return True
+
+    async def send_message(self, text):
+        self.messages.append(text)
+
+    async def upload_file(self, filepath, comment=None):
+        self.uploaded_files.append((filepath, comment))
+
+    async def upload_image(self, filepath, comment=None):
+        self.uploaded_images.append((filepath, comment))
 
 
-class TestTelegramUpdateInitialization:
-    """Test TelegramUpdate class initialization"""
-    
-    @patch('slackker.callbacks.basic.checkker.check_internet')
-    @patch('slackker.callbacks.basic.checkker.get_telegram_chat_id')
-    def test_telegram_update_init_success(self, mock_get_chat_id, mock_check_internet):
-        """Test successful TelegramUpdate initialization"""
-        mock_check_internet.return_value = True
-        mock_get_chat_id.return_value = "123456789"
-        
-        slackker = TelegramUpdate(token="1234567890:AAAAA_A111BBBBBCCC2DD3eEe44f5GGGgGG", verbose=0)
-        
-        assert slackker.token == "1234567890:AAAAA_A111BBBBBCCC2DD3eEe44f5GGGgGG"
-        assert slackker.channel == "123456789"
-        assert slackker.verbose == 0
-    
-    @patch('slackker.callbacks.basic.colors.prRed')
-    def test_telegram_update_init_no_token(self, mock_print_red):
-        """Test TelegramUpdate initialization with None token"""
-        slackker = TelegramUpdate(token=None)
-        mock_print_red.assert_called_once()
-    
-    @patch('slackker.callbacks.basic.checkker.check_internet')
-    @patch('slackker.callbacks.basic.checkker.get_telegram_chat_id')
-    def test_telegram_update_init_no_internet(self, mock_get_chat_id, mock_check_internet):
-        """Test TelegramUpdate initialization without internet"""
-        mock_check_internet.return_value = False
-        mock_get_chat_id.return_value = "123456789"
-        
-        slackker = TelegramUpdate(token="1234567890:AAAAA_A111BBBBBCCC2DD3eEe44f5GGGgGG")
-        mock_check_internet.assert_called_once()
-    
-    @patch('slackker.callbacks.basic.checkker.check_internet')
-    @patch('slackker.callbacks.basic.checkker.get_telegram_chat_id')
-    def test_telegram_update_init_invalid_token(self, mock_get_chat_id, mock_check_internet):
-        """Test TelegramUpdate initialization with invalid token"""
-        mock_check_internet.return_value = True
-        mock_get_chat_id.return_value = None
-        
-        slackker = TelegramUpdate(token="invalid_token")
-        mock_get_chat_id.assert_called_once()
+def _make_callback(verbose=0):
+    client = MockClient(verbose=verbose)
+    return SimpleCallback(client), client
 
 
-class TestSlackUpdateNotifierDecorator:
-    """Test SlackUpdate notifier decorator"""
-    
-    @patch('slackker.callbacks.basic.checkker.check_internet')
-    @patch('slackker.callbacks.basic.checkker.slack_connect')
-    @patch('slackker.callbacks.basic.WebClient')
-    @patch('slackker.callbacks.basic.functions.Slack.report_stats')
-    def test_notifier_with_tuple_return(self, mock_report, mock_webclient, mock_slack_connect, mock_check_internet):
-        """Test notifier decorator with tuple return value"""
-        mock_check_internet.return_value = True
-        mock_slack_connect.return_value = True
-        
-        slackker = SlackUpdate(token="test_token", channel="C123456", verbose=0)
-        
-        @slackker.notifier
-        def test_function():
-            return "value_1", "value_2"
-        
-        result = test_function()
-        
-        assert result == ("value_1", "value_2")
-        mock_report.assert_called_once()
-        
-        # Verify message content
-        call_args = mock_report.call_args
-        message = call_args[1]['text']
-        assert "test_function" in message
-        assert "Returned 2 outputs" in message
-        assert "value_1" in message
-        assert "value_2" in message
-    
-    @patch('slackker.callbacks.basic.checkker.check_internet')
-    @patch('slackker.callbacks.basic.checkker.slack_connect')
-    @patch('slackker.callbacks.basic.WebClient')
-    @patch('slackker.callbacks.basic.functions.Slack.report_stats')
-    def test_notifier_with_single_return(self, mock_report, mock_webclient, mock_slack_connect, mock_check_internet):
-        """Test notifier decorator with single return value"""
-        mock_check_internet.return_value = True
-        mock_slack_connect.return_value = True
-        
-        slackker = SlackUpdate(token="test_token", channel="C123456", verbose=0)
-        
-        @slackker.notifier
-        def test_function():
-            return "single_value"
-        
-        result = test_function()
-        
-        assert result == "single_value"
-        mock_report.assert_called_once()
-        
-        call_args = mock_report.call_args
-        message = call_args[1]['text']
-        assert "Returned output: single_value" in message
-    
-    @patch('slackker.callbacks.basic.checkker.check_internet')
-    @patch('slackker.callbacks.basic.checkker.slack_connect')
-    @patch('slackker.callbacks.basic.WebClient')
-    @patch('slackker.callbacks.basic.functions.Slack.report_stats')
-    def test_notifier_with_none_return(self, mock_report, mock_webclient, mock_slack_connect, mock_check_internet):
-        """Test notifier decorator with None return value"""
-        mock_check_internet.return_value = True
-        mock_slack_connect.return_value = True
-        
-        slackker = SlackUpdate(token="test_token", channel="C123456", verbose=0)
-        
-        @slackker.notifier
-        def test_function():
+def _make_update(verbose=0):
+    """Legacy helper using deprecated Update."""
+    client = MockClient(verbose=verbose)
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter("always")
+        return Update(client), client
+
+
+# ── SimpleCallback tests ──────────────────────────────────────
+
+class TestSimpleCallbackNotifier:
+    """Test SimpleCallback.notifier decorator."""
+
+    def test_notifier_with_tuple_return(self):
+        cb, client = _make_callback()
+
+        @cb.notifier
+        def func():
+            return "a", "b"
+
+        result = func()
+        assert result == ("a", "b")
+        assert len(client.messages) == 1
+        assert "func" in client.messages[0]
+        assert "Returned 2 outputs" in client.messages[0]
+        assert "a" in client.messages[0]
+        assert "b" in client.messages[0]
+
+    def test_notifier_with_single_return(self):
+        cb, client = _make_callback()
+
+        @cb.notifier
+        def func():
+            return "single"
+
+        result = func()
+        assert result == "single"
+        assert "Returned output: single" in client.messages[0]
+
+    def test_notifier_with_none_return(self):
+        cb, client = _make_callback()
+
+        @cb.notifier
+        def func():
             return None
-        
-        result = test_function()
-        
+
+        result = func()
         assert result is None
-        mock_report.assert_called_once()
-        
-        call_args = mock_report.call_args
-        message = call_args[1]['text']
-        assert "Returned output: None" in message
-    
-    @patch('slackker.callbacks.basic.checkker.check_internet')
-    @patch('slackker.callbacks.basic.checkker.slack_connect')
-    @patch('slackker.callbacks.basic.WebClient')
-    @patch('slackker.callbacks.basic.functions.Slack.report_stats')
-    def test_notifier_execution_time(self, mock_report, mock_webclient, mock_slack_connect, mock_check_internet):
-        """Test notifier decorator captures execution time"""
+        assert "Returned output: None" in client.messages[0]
+
+    def test_notifier_execution_time(self):
         import time
-        
-        mock_check_internet.return_value = True
-        mock_slack_connect.return_value = True
-        
-        slackker = SlackUpdate(token="test_token", channel="C123456", verbose=0)
-        
-        @slackker.notifier
-        def test_function():
-            time.sleep(0.1)
-            return "result"
-        
-        result = test_function()
-        
-        assert result == "result"
-        call_args = mock_report.call_args
-        message = call_args[1]['text']
-        assert "Execution time:" in message
-    
-    @patch('slackker.callbacks.basic.checkker.check_internet')
-    @patch('slackker.callbacks.basic.checkker.slack_connect')
-    @patch('slackker.callbacks.basic.WebClient')
-    @patch('slackker.callbacks.basic.functions.Slack.report_stats')
-    def test_notifier_with_args(self, mock_report, mock_webclient, mock_slack_connect, mock_check_internet):
-        """Test notifier decorator with function arguments"""
-        mock_check_internet.return_value = True
-        mock_slack_connect.return_value = True
-        
-        slackker = SlackUpdate(token="test_token", channel="C123456", verbose=1)
-        
-        @slackker.notifier
-        def test_function(a, b):
+        cb, client = _make_callback()
+
+        @cb.notifier
+        def func():
+            time.sleep(0.05)
+            return "done"
+
+        func()
+        assert "Execution time:" in client.messages[0]
+
+    def test_notifier_with_args(self):
+        cb, client = _make_callback(verbose=1)
+
+        @cb.notifier
+        def add(a, b):
             return a + b
-        
-        result = test_function(10, 20)
-        
+
+        result = add(10, 20)
         assert result == 30
-    
-    @patch('slackker.callbacks.basic.checkker.check_internet')
-    @patch('slackker.callbacks.basic.checkker.slack_connect')
-    @patch('slackker.callbacks.basic.WebClient')
-    @patch('slackker.callbacks.basic.functions.Slack.report_stats')
-    def test_notifier_with_exception(self, mock_report, mock_webclient, mock_slack_connect, mock_check_internet):
-        """Test notifier decorator when function raises exception"""
-        mock_check_internet.return_value = True
-        mock_slack_connect.return_value = True
-        
-        slackker = SlackUpdate(token="test_token", channel="C123456", verbose=0)
-        
-        @slackker.notifier
-        def test_function():
+
+    def test_notifier_with_exception(self):
+        cb, client = _make_callback()
+
+        @cb.notifier
+        def func():
             raise ValueError("Test error")
-        
+
         with pytest.raises(ValueError):
-            test_function()
+            func()
+
+    def test_notifier_with_empty_tuple(self):
+        cb, client = _make_callback()
+
+        @cb.notifier
+        def func():
+            return ()
+
+        result = func()
+        assert result == ()
+
+    def test_notifier_with_dict_return(self):
+        cb, client = _make_callback()
+
+        @cb.notifier
+        def func():
+            return {"key": "value"}
+
+        result = func()
+        assert result == {"key": "value"}
+
+    def test_notifier_with_list_return(self):
+        cb, client = _make_callback()
+
+        @cb.notifier
+        def func():
+            return [1, 2, 3]
+
+        result = func()
+        assert result == [1, 2, 3]
 
 
-class TestTelegramUpdateNotifierDecorator:
-    """Test TelegramUpdate notifier decorator"""
-    
-    @patch('slackker.callbacks.basic.checkker.check_internet')
-    @patch('slackker.callbacks.basic.checkker.get_telegram_chat_id')
-    @patch('slackker.callbacks.basic.functions.Telegram.report_stats')
-    def test_telegram_notifier_with_tuple_return(self, mock_report, mock_get_chat_id, mock_check_internet):
-        """Test Telegram notifier decorator with tuple return value"""
-        mock_check_internet.return_value = True
-        mock_get_chat_id.return_value = "123456789"
-        
-        slackker = TelegramUpdate(token="test_token", verbose=0)
-        
-        @slackker.notifier
-        def test_function():
-            return "value_1", "value_2"
-        
-        result = test_function()
-        
-        assert result == ("value_1", "value_2")
-        mock_report.assert_called_once()
-        
-        call_args = mock_report.call_args
-        message = call_args[1]['text']
-        assert "test_function" in message
-        assert "Returned 2 outputs" in message
-    
-    @patch('slackker.callbacks.basic.checkker.check_internet')
-    @patch('slackker.callbacks.basic.checkker.get_telegram_chat_id')
-    @patch('slackker.callbacks.basic.functions.Telegram.report_stats')
-    def test_telegram_notifier_with_single_return(self, mock_report, mock_get_chat_id, mock_check_internet):
-        """Test Telegram notifier decorator with single return value"""
-        mock_check_internet.return_value = True
-        mock_get_chat_id.return_value = "123456789"
-        
-        slackker = TelegramUpdate(token="test_token", verbose=0)
-        
-        @slackker.notifier
-        def test_function():
-            return "single_value"
-        
-        result = test_function()
-        
-        assert result == "single_value"
-        mock_report.assert_called_once()
-    
-    @patch('slackker.callbacks.basic.checkker.check_internet')
-    @patch('slackker.callbacks.basic.checkker.get_telegram_chat_id')
-    @patch('slackker.callbacks.basic.functions.Telegram.report_stats')
-    def test_telegram_notifier_with_none_return(self, mock_report, mock_get_chat_id, mock_check_internet):
-        """Test Telegram notifier decorator with None return value"""
-        mock_check_internet.return_value = True
-        mock_get_chat_id.return_value = "123456789"
-        
-        slackker = TelegramUpdate(token="test_token", verbose=0)
-        
-        @slackker.notifier
-        def test_function():
-            return None
-        
-        result = test_function()
-        
-        assert result is None
-        mock_report.assert_called_once()
-    
-    @patch('slackker.callbacks.basic.checkker.check_internet')
-    @patch('slackker.callbacks.basic.checkker.get_telegram_chat_id')
-    @patch('slackker.callbacks.basic.functions.Telegram.report_stats')
-    def test_telegram_notifier_verbose_logging(self, mock_report, mock_get_chat_id, mock_check_internet):
-        """Test Telegram notifier with verbose logging enabled"""
-        mock_check_internet.return_value = True
-        mock_get_chat_id.return_value = "123456789"
-        
-        slackker = TelegramUpdate(token="test_token", verbose=1)
-        
-        @slackker.notifier
-        def test_function(x):
-            return x * 2
-        
-        result = test_function(5)
-        
-        assert result == 10
+class TestSimpleCallbackNotify:
+    """Test SimpleCallback.notify method."""
+
+    def test_notify_with_event(self):
+        cb, client = _make_callback()
+        cb.notify("my_event", detail="arg2")
+
+        assert len(client.messages) == 1
+        assert "Notification: my_event" in client.messages[0]
+        assert "detail: arg2" in client.messages[0]
+
+    def test_notify_with_kwargs(self):
+        cb, client = _make_callback()
+        cb.notify(value="string", status="completed")
+
+        msg = client.messages[0]
+        assert "value: string" in msg
+        assert "status: completed" in msg
+
+    def test_notify_with_mixed(self):
+        cb, client = _make_callback()
+        cb.notify("evt", arg2="a2", value="kwval")
+
+        msg = client.messages[0]
+        assert "evt" in msg
+        assert "arg2: a2" in msg
+        assert "value: kwval" in msg
+
+    def test_notify_timestamp(self):
+        cb, client = _make_callback()
+        cb.notify()
+
+        assert "Notification:" in client.messages[0]
+
+    def test_notify_with_attachment(self):
+        cb, client = _make_callback()
+        cb.notify("done", attachment="/tmp/model.ckpt")
+
+        assert len(client.uploaded_files) == 1
+        assert client.uploaded_files[0][0] == "/tmp/model.ckpt"
+        assert "done" in client.uploaded_files[0][1]
 
 
-class TestSlackUpdateNotifyMethod:
-    """Test SlackUpdate notify method"""
-    
-    @patch('slackker.callbacks.basic.checkker.check_internet')
-    @patch('slackker.callbacks.basic.checkker.slack_connect')
-    @patch('slackker.callbacks.basic.WebClient')
-    @patch('slackker.callbacks.basic.functions.Slack.report_stats')
-    def test_notify_with_args(self, mock_report, mock_webclient, mock_slack_connect, mock_check_internet):
-        """Test notify method with positional arguments"""
-        mock_check_internet.return_value = True
-        mock_slack_connect.return_value = True
-        
-        slackker = SlackUpdate(token="test_token", channel="C123456", verbose=0)
-        slackker.notify("arg1", detail="This is argument 2 = arg2")
-        
-        mock_report.assert_called_once()
-        call_args = mock_report.call_args
-        message = call_args[1]['text']
-        assert "Notification: " in message
-        assert "arg1" in message
-        assert "This is argument 2 = arg2" in message
-    
-    @patch('slackker.callbacks.basic.checkker.check_internet')
-    @patch('slackker.callbacks.basic.checkker.slack_connect')
-    @patch('slackker.callbacks.basic.WebClient')
-    @patch('slackker.callbacks.basic.functions.Slack.report_stats')
-    def test_notify_with_kwargs(self, mock_report, mock_webclient, mock_slack_connect, mock_check_internet):
-        """Test notify method with keyword arguments"""
-        mock_check_internet.return_value = True
-        mock_slack_connect.return_value = True
-        
-        slackker = SlackUpdate(token="test_token", channel="C123456", verbose=0)
-        slackker.notify(value="This is a string", status="completed")
-        
-        mock_report.assert_called_once()
-        call_args = mock_report.call_args
-        message = call_args[1]['text']
-        assert "value: This is a string" in message
-        assert "status: completed" in message
-    
-    @patch('slackker.callbacks.basic.checkker.check_internet')
-    @patch('slackker.callbacks.basic.checkker.slack_connect')
-    @patch('slackker.callbacks.basic.WebClient')
-    @patch('slackker.callbacks.basic.functions.Slack.report_stats')
-    def test_notify_with_mixed_args_and_kwargs(self, mock_report, mock_webclient, mock_slack_connect, mock_check_internet):
-        """Test notify method with both positional and keyword arguments"""
-        mock_check_internet.return_value = True
-        mock_slack_connect.return_value = True
-        
-        slackker = SlackUpdate(token="test_token", channel="C123456", verbose=0)
-        slackker.notify("arg1", arg2="arg2", value="kwarg_value")
-        
-        mock_report.assert_called_once()
-        call_args = mock_report.call_args
-        message = call_args[1]['text']
-        assert "arg1" in message
-        assert "arg2: arg2" in message
-        assert "value: kwarg_value" in message
-    
-    @patch('slackker.callbacks.basic.checkker.check_internet')
-    @patch('slackker.callbacks.basic.checkker.slack_connect')
-    @patch('slackker.callbacks.basic.WebClient')
-    @patch('slackker.callbacks.basic.functions.Slack.report_stats')
-    def test_notify_timestamp(self, mock_report, mock_webclient, mock_slack_connect, mock_check_internet):
-        """Test notify method includes timestamp"""
-        mock_check_internet.return_value = True
-        mock_slack_connect.return_value = True
-        
-        slackker = SlackUpdate(token="test_token", channel="C123456", verbose=0)
-        slackker.notify()
-        
-        mock_report.assert_called_once()
-        call_args = mock_report.call_args
-        message = call_args[1]['text']
-        assert "Notification: " in message
+class TestAsyncNotify:
+    """Test async variant of notify."""
 
-    @patch('slackker.callbacks.basic.checkker.check_internet')
-    @patch('slackker.callbacks.basic.checkker.slack_connect')
-    @patch('slackker.callbacks.basic.WebClient')
-    @patch('slackker.callbacks.basic.functions.Slack.report_stats')
-    def test_notify_with_attachment(self, mock_report, mock_webclient, mock_slack_connect, mock_check_internet):
-        """Test notify method forwards attachment for Slack"""
-        mock_check_internet.return_value = True
-        mock_slack_connect.return_value = True
+    @pytest.mark.asyncio
+    async def test_async_notify(self):
+        cb, client = _make_callback()
+        await cb.async_notify("async_event", key="val")
 
-        slackker = SlackUpdate(token="test_token", channel="C123456", verbose=0)
-        slackker.notify("training_complete", attachment="/tmp/model.ckpt")
+        assert len(client.messages) == 1
+        assert "async_event" in client.messages[0]
+        assert "key: val" in client.messages[0]
 
-        mock_report.assert_called_once()
-        call_args = mock_report.call_args
-        assert call_args[1]['attachment'] == "/tmp/model.ckpt"
-        assert "attachment" not in call_args[1]['text']
+    @pytest.mark.asyncio
+    async def test_async_notify_attachment(self):
+        cb, client = _make_callback()
+        await cb.async_notify("done", attachment="/tmp/file.zip")
+
+        assert len(client.uploaded_files) == 1
 
 
-class TestTelegramUpdateNotifyMethod:
-    """Test TelegramUpdate notify method"""
-    
-    @patch('slackker.callbacks.basic.checkker.check_internet')
-    @patch('slackker.callbacks.basic.checkker.get_telegram_chat_id')
-    @patch('slackker.callbacks.basic.functions.Telegram.report_stats')
-    def test_telegram_notify_with_args(self, mock_report, mock_get_chat_id, mock_check_internet):
-        """Test Telegram notify method with positional arguments"""
-        mock_check_internet.return_value = True
-        mock_get_chat_id.return_value = "123456789"
-        
-        slackker = TelegramUpdate(token="test_token", verbose=0)
-        slackker.notify("arg1", detail="This is argument 2 = arg2")
-        
-        mock_report.assert_called_once()
-        call_args = mock_report.call_args
-        message = call_args[1]['text']
-        assert "Notification: " in message
-        assert "arg1" in message
-        assert "This is argument 2 = arg2" in message
-    
-    @patch('slackker.callbacks.basic.checkker.check_internet')
-    @patch('slackker.callbacks.basic.checkker.get_telegram_chat_id')
-    @patch('slackker.callbacks.basic.functions.Telegram.report_stats')
-    def test_telegram_notify_with_kwargs(self, mock_report, mock_get_chat_id, mock_check_internet):
-        """Test Telegram notify method with keyword arguments"""
-        mock_check_internet.return_value = True
-        mock_get_chat_id.return_value = "123456789"
-        
-        slackker = TelegramUpdate(token="test_token", verbose=0)
-        slackker.notify(value="This is a string")
-        
-        mock_report.assert_called_once()
-        call_args = mock_report.call_args
-        message = call_args[1]['text']
-        assert "value: This is a string" in message
-    
-    @patch('slackker.callbacks.basic.checkker.check_internet')
-    @patch('slackker.callbacks.basic.checkker.get_telegram_chat_id')
-    @patch('slackker.callbacks.basic.functions.Telegram.report_stats')
-    def test_telegram_notify_with_mixed_args_and_kwargs(self, mock_report, mock_get_chat_id, mock_check_internet):
-        """Test Telegram notify method with both positional and keyword arguments"""
-        mock_check_internet.return_value = True
-        mock_get_chat_id.return_value = "123456789"
-        
-        slackker = TelegramUpdate(token="test_token", verbose=0)
-        slackker.notify("arg1", value="kwarg_value")
-        
-        mock_report.assert_called_once()
-        call_args = mock_report.call_args
-        message = call_args[1]['text']
-        assert "arg1" in message
-        assert "value: kwarg_value" in message
+# ── Deprecated Update alias test ─────────────────────────────
 
-    @patch('slackker.callbacks.basic.checkker.check_internet')
-    @patch('slackker.callbacks.basic.checkker.get_telegram_chat_id')
-    @patch('slackker.callbacks.basic.functions.Telegram.report_stats')
-    def test_telegram_notify_with_attachment(self, mock_report, mock_get_chat_id, mock_check_internet):
-        """Test Telegram notify method forwards attachment"""
-        mock_check_internet.return_value = True
-        mock_get_chat_id.return_value = "123456789"
+class TestUpdateDeprecation:
+    """Ensure Update emits DeprecationWarning and still works."""
 
-        slackker = TelegramUpdate(token="test_token", verbose=0)
-        slackker.notify("training_complete", attachment="/tmp/logs.zip")
+    def test_update_deprecation_warning(self):
+        client = MockClient()
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            obj = Update(client)
+            assert any(issubclass(x.category, DeprecationWarning) for x in w)
+            assert any("Update is deprecated" in str(x.message) for x in w)
 
-        mock_report.assert_called_once()
-        call_args = mock_report.call_args
-        assert call_args[1]['attachment'] == "/tmp/logs.zip"
-        assert "attachment" not in call_args[1]['text']
+    def test_update_still_functions(self):
+        client = MockClient()
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            obj = Update(client)
+
+        obj.notify("test_event", x=1)
+        assert any("test_event" in m for m in client.messages)
 
 
-class TestIntegrationScenarios:
-    """Integration tests with combined notifier and notify usage"""
-    
-    @patch('slackker.callbacks.basic.checkker.check_internet')
-    @patch('slackker.callbacks.basic.checkker.slack_connect')
-    @patch('slackker.callbacks.basic.WebClient')
-    @patch('slackker.callbacks.basic.functions.Slack.report_stats')
-    def test_slack_complete_workflow(self, mock_report, mock_webclient, mock_slack_connect, mock_check_internet):
-        """Test complete Slack workflow with notifier and notify"""
-        mock_check_internet.return_value = True
-        mock_slack_connect.return_value = True
-        
-        slackker = SlackUpdate(token="xoxb-test", channel="C123456", verbose=0)
-        
-        @slackker.notifier
+# ── Backward-compat shim tests ───────────────────────────────
+
+class TestSlackUpdateShim:
+    """Test backward-compatible SlackUpdate."""
+
+    @patch("slackker.callbacks.basic.SlackClient")
+    def test_init_deprecation_warning(self, mock_cls):
+        mock_client = MagicMock()
+        mock_client.connect = AsyncMock(return_value=True)
+        mock_cls.return_value = mock_client
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            obj = SlackUpdate(token="test", channel="C123", verbose=0)
+            assert len(w) == 1
+            assert issubclass(w[0].category, DeprecationWarning)
+            assert "SlackUpdate is deprecated" in str(w[0].message)
+
+    @patch("slackker.callbacks.basic.SlackClient")
+    def test_init_success(self, mock_cls):
+        mock_client = MockClient()
+        mock_client.connect = AsyncMock(return_value=True)
+        mock_cls.return_value = mock_client
+
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            obj = SlackUpdate(token="test", channel="C123", verbose=0)
+
+        assert hasattr(obj, "client")
+        assert obj.client is mock_client
+
+    def test_init_no_token(self):
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            obj = SlackUpdate(token=None, channel="C123")
+        assert not hasattr(obj, "client")
+
+
+class TestTelegramUpdateShim:
+    """Test backward-compatible TelegramUpdate."""
+
+    @patch("slackker.callbacks.basic.TelegramClient")
+    def test_init_deprecation_warning(self, mock_cls):
+        mock_client = MagicMock()
+        mock_client.connect = AsyncMock(return_value=True)
+        mock_cls.return_value = mock_client
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            obj = TelegramUpdate(token="test", verbose=0)
+            assert len(w) == 1
+            assert issubclass(w[0].category, DeprecationWarning)
+
+    @patch("slackker.callbacks.basic.TelegramClient")
+    def test_init_success(self, mock_cls):
+        mock_client = MockClient()
+        mock_client.connect = AsyncMock(return_value=True)
+        mock_cls.return_value = mock_client
+
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            obj = TelegramUpdate(token="test", verbose=0)
+
+        assert hasattr(obj, "client")
+
+    def test_init_no_token(self):
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            obj = TelegramUpdate(token=None)
+        assert not hasattr(obj, "client")
+
+
+class TestShimWorkflows:
+    """Integration-style tests using the shims with a mock client."""
+
+    @patch("slackker.callbacks.basic.SlackClient")
+    def test_slack_notifier_and_notify(self, mock_cls):
+        mock_client = MockClient()
+        mock_client.connect = AsyncMock(return_value=True)
+        mock_cls.return_value = mock_client
+
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            obj = SlackUpdate(token="xoxb-test", channel="C123", verbose=0)
+
+        @obj.notifier
         def compute(x, y):
             return x + y, x * y
-        
-        # Function call with notifier
-        sum_result, prod_result = compute(5, 3)
-        assert sum_result == 8
-        assert prod_result == 15
-        
-        # Script completion notification
-        slackker.notify(f"Sum: {sum_result}", product=f"{prod_result}")
-        
-        # Verify both calls were made
-        assert mock_report.call_count >= 2
-    
-    @patch('slackker.callbacks.basic.checkker.check_internet')
-    @patch('slackker.callbacks.basic.checkker.get_telegram_chat_id')
-    @patch('slackker.callbacks.basic.functions.Telegram.report_stats')
-    def test_telegram_complete_workflow(self, mock_report, mock_get_chat_id, mock_check_internet):
-        """Test complete Telegram workflow with notifier and notify"""
-        mock_check_internet.return_value = True
-        mock_get_chat_id.return_value = "123456789"
-        
-        slackker = TelegramUpdate(token="1234567890:AAAAA_A111BBBBBCCC2DD3eEe44f5GGGgGG")
-        
-        @slackker.notifier
-        def your_function():
-            return "value_1", "value_2"
-        
-        result = your_function()
-        slackker.notify("arg1", detail="This is argument 2 = arg2", value="This is a string")
-        
-        # Verify both calls were made
-        assert mock_report.call_count >= 2
-        
-        # Verify correct token and channel were used
-        for call_obj in mock_report.call_args_list:
-            assert call_obj[1]['token'] == "1234567890:AAAAA_A111BBBBBCCC2DD3eEe44f5GGGgGG"
-            assert call_obj[1]['channel'] == "123456789"
+
+        s, p = compute(5, 3)
+        assert s == 8
+        assert p == 15
+
+        obj.notify(f"Sum: {s}", product=f"{p}")
+        assert len(mock_client.messages) == 2
+
+    @patch("slackker.callbacks.basic.TelegramClient")
+    def test_telegram_notifier_and_notify(self, mock_cls):
+        mock_client = MockClient()
+        mock_client.connect = AsyncMock(return_value=True)
+        mock_cls.return_value = mock_client
+
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            obj = TelegramUpdate(token="123:ABC", verbose=0)
+
+        @obj.notifier
+        def func():
+            return "v1", "v2"
+
+        func()
+        obj.notify("arg1", detail="arg2", value="str")
+        assert len(mock_client.messages) == 2
 
 
-class TestEdgeCases:
-    """Test edge cases and error handling"""
-    
-    @patch('slackker.callbacks.basic.checkker.check_internet')
-    @patch('slackker.callbacks.basic.checkker.slack_connect')
-    @patch('slackker.callbacks.basic.WebClient')
-    @patch('slackker.callbacks.basic.functions.Slack.report_stats')
-    def test_notifier_with_empty_tuple_return(self, mock_report, mock_webclient, mock_slack_connect, mock_check_internet):
-        """Test notifier with empty tuple return"""
-        mock_check_internet.return_value = True
-        mock_slack_connect.return_value = True
-        
-        slackker = SlackUpdate(token="test_token", channel="C123456", verbose=0)
-        
-        @slackker.notifier
-        def test_function():
-            return ()
-        
-        result = test_function()
-        assert result == ()
-        mock_report.assert_called_once()
-    
-    @patch('slackker.callbacks.basic.checkker.check_internet')
-    @patch('slackker.callbacks.basic.checkker.slack_connect')
-    @patch('slackker.callbacks.basic.WebClient')
-    @patch('slackker.callbacks.basic.functions.Slack.report_stats')
-    def test_notifier_with_dict_return(self, mock_report, mock_webclient, mock_slack_connect, mock_check_internet):
-        """Test notifier with dict return value"""
-        mock_check_internet.return_value = True
-        mock_slack_connect.return_value = True
-        
-        slackker = SlackUpdate(token="test_token", channel="C123456", verbose=0)
-        
-        @slackker.notifier
-        def test_function():
-            return {"key": "value"}
-        
-        result = test_function()
-        assert result == {"key": "value"}
-        mock_report.assert_called_once()
-    
-    @patch('slackker.callbacks.basic.checkker.check_internet')
-    @patch('slackker.callbacks.basic.checkker.slack_connect')
-    @patch('slackker.callbacks.basic.WebClient')
-    @patch('slackker.callbacks.basic.functions.Slack.report_stats')
-    def test_notifier_with_list_return(self, mock_report, mock_webclient, mock_slack_connect, mock_check_internet):
-        """Test notifier with list return value"""
-        mock_check_internet.return_value = True
-        mock_slack_connect.return_value = True
-        
-        slackker = SlackUpdate(token="test_token", channel="C123456", verbose=0)
-        
-        @slackker.notifier
-        def test_function():
-            return [1, 2, 3]
-        
-        result = test_function()
-        assert result == [1, 2, 3]
-        mock_report.assert_called_once()
-    
-    @patch('slackker.callbacks.basic.checkker.check_internet')
-    @patch('slackker.callbacks.basic.checkker.slack_connect')
-    @patch('slackker.callbacks.basic.WebClient')
-    @patch('slackker.callbacks.basic.functions.Slack.report_stats')
-    def test_notify_without_args_or_kwargs(self, mock_report, mock_webclient, mock_slack_connect, mock_check_internet):
-        """Test notify method without any arguments"""
-        mock_check_internet.return_value = True
-        mock_slack_connect.return_value = True
-        
-        slackker = SlackUpdate(token="test_token", channel="C123456", verbose=0)
-        slackker.notify()
-        
-        mock_report.assert_called_once()
-        call_args = mock_report.call_args
-        message = call_args[1]['text']
-        assert "Notification: " in message
-    
-    @patch('slackker.callbacks.basic.checkker.check_internet')
-    @patch('slackker.callbacks.basic.checkker.get_telegram_chat_id')
-    @patch('slackker.callbacks.basic.functions.Telegram.report_stats')
-    def test_telegram_notify_empty_call(self, mock_report, mock_get_chat_id, mock_check_internet):
-        """Test Telegram notify with no arguments"""
-        mock_check_internet.return_value = True
-        mock_get_chat_id.return_value = "123456789"
-        
-        slackker = TelegramUpdate(token="test_token", verbose=0)
-        slackker.notify()
-        
-        mock_report.assert_called_once()
+# ── Auto-connect tests ───────────────────────────────────────
+
+class DisconnectedMockClient(MockClient):
+    """MockClient that starts disconnected and records connect() calls."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.connect_calls = 0
+        self._connected = False
+
+    @property
+    def is_connected(self):
+        return self._connected
+
+    async def connect(self):
+        self.connect_calls += 1
+        self._connected = True
+        return True
 
 
-class TestVerboseLevels:
-    """Test different verbose levels"""
-    
-    @patch('slackker.callbacks.basic.checkker.check_internet')
-    @patch('slackker.callbacks.basic.checkker.slack_connect')
-    @patch('slackker.callbacks.basic.WebClient')
-    @patch('slackker.callbacks.basic.functions.Slack.report_stats')
-    @patch('slackker.callbacks.basic.colors.prCyan')
-    def test_slack_verbose_level_1(self, mock_print_cyan, mock_report, mock_webclient, mock_slack_connect, mock_check_internet):
-        """Test verbose level 1 for Slack"""
-        mock_check_internet.return_value = True
-        mock_slack_connect.return_value = True
-        
-        slackker = SlackUpdate(token="test_token", channel="C123456", verbose=1)
-        
-        @slackker.notifier
-        def test_function():
-            return "result"
-        
-        test_function()
-        # Verbose level 1 should print info
-    
-    @patch('slackker.callbacks.basic.checkker.check_internet')
-    @patch('slackker.callbacks.basic.checkker.get_telegram_chat_id')
-    @patch('slackker.callbacks.basic.functions.Telegram.report_stats')
-    def test_telegram_verbose_level_0(self, mock_report, mock_get_chat_id, mock_check_internet):
-        """Test verbose level 0 for Telegram (silent mode)"""
-        mock_check_internet.return_value = True
-        mock_get_chat_id.return_value = "123456789"
-        
-        slackker = TelegramUpdate(token="test_token", verbose=0)
-        
-        @slackker.notifier
-        def test_function():
-            return "result"
-        
-        result = test_function()
-        assert result == "result"
-        mock_report.assert_called_once()
+class TestAutoConnect:
+    """Verify that SimpleCallback calls connect() when the client is not yet connected."""
+
+    def test_connects_when_not_connected(self):
+        client = DisconnectedMockClient()
+        assert not client.is_connected
+        SimpleCallback(client)
+        assert client.connect_calls == 1
+        assert client.is_connected
+
+    def test_skips_connect_when_already_connected(self):
+        client = MockClient()          # is_connected always True
+        SimpleCallback(client)
+        # MockClient has no connect_calls attr — just ensure no AttributeError
+        assert client.is_connected
 
 
 if __name__ == "__main__":

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,162 @@
+"""Tests for slackker.core client abstraction layer."""
+
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+from slackker.core.client import BaseClient, _run_sync
+from slackker.core.slack import SlackClient
+from slackker.core.telegram import TelegramClient
+
+
+class TestBaseClient:
+    """Test the ABC contract."""
+
+    def test_cannot_instantiate_directly(self):
+        with pytest.raises(TypeError):
+            BaseClient(verbose=0)
+
+    def test_subclass_must_implement_abstract_methods(self):
+        class Incomplete(BaseClient):
+            @property
+            def platform(self):
+                return "test"
+
+        with pytest.raises(TypeError):
+            Incomplete(verbose=0)
+
+
+class TestSlackClient:
+    """Test SlackClient."""
+
+    def test_init_requires_token(self):
+        with pytest.raises(ValueError, match="Slack API token is required"):
+            SlackClient(token="", channel="C123")
+
+    def test_init_stores_attributes(self):
+        client = SlackClient(token="xoxb-test", channel="C123", verbose=2)
+        assert client.platform == "slack"
+        assert client.channel == "C123"
+        assert client.verbose == 2
+
+    @pytest.mark.asyncio
+    @patch("slackker.core.slack.network.check_connection", new_callable=AsyncMock, return_value=True)
+    @patch("slackker.core.slack.network.verify_slack_token", new_callable=AsyncMock, return_value=True)
+    async def test_connect_success(self, mock_verify, mock_check):
+        client = SlackClient(token="xoxb-test", channel="C123")
+        result = await client.connect()
+        assert result is True
+        mock_check.assert_awaited_once()
+        mock_verify.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    @patch("slackker.core.slack.network.check_connection", new_callable=AsyncMock, return_value=False)
+    @patch("slackker.core.slack.network.verify_slack_token", new_callable=AsyncMock, return_value=True)
+    async def test_connect_no_internet(self, mock_verify, mock_check):
+        client = SlackClient(token="xoxb-test", channel="C123")
+        result = await client.connect()
+        assert result is False
+
+    @pytest.mark.asyncio
+    @patch("slackker.core.slack.network.check_connection", new_callable=AsyncMock, return_value=True)
+    @patch("slackker.core.slack.network.verify_slack_token", new_callable=AsyncMock, return_value=False)
+    async def test_connect_invalid_token(self, mock_verify, mock_check):
+        client = SlackClient(token="xoxb-bad", channel="C123")
+        result = await client.connect()
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_send_message(self):
+        client = SlackClient(token="xoxb-test", channel="C123", verbose=0)
+        client._client = AsyncMock()
+        client._client.chat_postMessage = AsyncMock()
+
+        await client.send_message("Hello")
+        client._client.chat_postMessage.assert_awaited_once_with(channel="C123", text="Hello")
+
+    @pytest.mark.asyncio
+    async def test_upload_file_invalid_path(self):
+        client = SlackClient(token="xoxb-test", channel="C123", verbose=0)
+        client._client = AsyncMock()
+        # Should not raise, just log an error
+        await client.upload_file("/nonexistent/file.txt")
+        client._client.files_upload_v2.assert_not_awaited()
+
+    def test_send_message_sync(self):
+        client = SlackClient(token="xoxb-test", channel="C123", verbose=0)
+        client._client = MagicMock()
+        # Mock the async method to return a coroutine
+        client.send_message = AsyncMock()
+        client.send_message_sync("Hello sync")
+        client.send_message.assert_awaited_once_with("Hello sync")
+
+
+class TestTelegramClient:
+    """Test TelegramClient."""
+
+    def test_init_requires_token(self):
+        with pytest.raises(ValueError, match="Telegram API token is required"):
+            TelegramClient(token="", verbose=0)
+
+    def test_init_stores_attributes(self):
+        client = TelegramClient(token="123:ABC", verbose=1)
+        assert client.platform == "telegram"
+        assert client.verbose == 1
+        assert client.chat_id is None
+
+    def test_init_with_chat_id(self):
+        client = TelegramClient(token="123:ABC", chat_id="99999", verbose=0)
+        assert client.chat_id == "99999"
+
+    @pytest.mark.asyncio
+    @patch("slackker.core.telegram.network.check_connection", new_callable=AsyncMock, return_value=True)
+    @patch("slackker.core.telegram.network.get_telegram_chat_id", new_callable=AsyncMock, return_value="12345")
+    async def test_connect_discovers_chat_id(self, mock_get_id, mock_check):
+        client = TelegramClient(token="123:ABC", verbose=0)
+        result = await client.connect()
+        assert result is True
+        assert client.chat_id == "12345"
+
+    @pytest.mark.asyncio
+    @patch("slackker.core.telegram.network.check_connection", new_callable=AsyncMock, return_value=True)
+    @patch("slackker.core.telegram.network.get_telegram_chat_id", new_callable=AsyncMock, return_value=None)
+    async def test_connect_no_chat_id(self, mock_get_id, mock_check):
+        client = TelegramClient(token="123:ABC", verbose=0)
+        result = await client.connect()
+        assert result is False
+
+    @pytest.mark.asyncio
+    @patch("slackker.core.telegram.network.check_connection", new_callable=AsyncMock, return_value=False)
+    async def test_connect_no_internet(self, mock_check):
+        client = TelegramClient(token="123:ABC", verbose=0)
+        result = await client.connect()
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_send_message(self):
+        client = TelegramClient(token="123:ABC", chat_id="99999", verbose=0)
+        with patch("slackker.core.telegram.httpx.AsyncClient") as mock_client_cls:
+            mock_response = MagicMock()
+            mock_response.raise_for_status = MagicMock()
+            mock_http = AsyncMock()
+            mock_http.post = AsyncMock(return_value=mock_response)
+            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_http)
+            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            await client.send_message("Test message")
+            mock_http.post.assert_awaited_once()
+
+    def test_send_message_sync(self):
+        client = TelegramClient(token="123:ABC", chat_id="99999", verbose=0)
+        client.send_message = AsyncMock()
+        client.send_message_sync("Hello sync")
+        client.send_message.assert_awaited_once_with("Hello sync")
+
+
+class TestRunSync:
+    """Test the _run_sync helper."""
+
+    def test_run_sync_basic(self):
+        async def async_add(a, b):
+            return a + b
+
+        result = _run_sync(async_add(2, 3))
+        assert result == 5

--- a/tests/test_keras.py
+++ b/tests/test_keras.py
@@ -1,887 +1,381 @@
 """
-Comprehensive tests for slackker.callbacks.keras module
-Tests cover SlackUpdate and TelegramUpdate Keras callback classes
+Comprehensive tests for slackker.callbacks.keras module.
+Tests cover the new unified KerasCallback class and backward-compatible shims.
 """
 
 import pytest
-import argparse
+import warnings
 import numpy as np
-from unittest.mock import Mock, MagicMock, patch, call
-from datetime import datetime
-from slackker.callbacks.keras import SlackUpdate, TelegramUpdate
+from unittest.mock import AsyncMock, MagicMock, patch
+from slackker.callbacks.keras import KerasCallback, SlackUpdate, TelegramUpdate
+from slackker.core.client import BaseClient
 
 
-class TestSlackUpdateKerasInitialization:
-    """Test SlackUpdate Keras callback initialization"""
-    
-    @patch('slackker.callbacks.keras.checkker.check_internet')
-    @patch('slackker.callbacks.keras.checkker.slack_connect')
-    @patch('slackker.callbacks.keras.WebClient')
-    def test_slack_keras_init_success(self, mock_webclient, mock_slack_connect, mock_check_internet):
-        """Test successful SlackUpdate Keras callback initialization"""
-        mock_check_internet.return_value = True
-        mock_slack_connect.return_value = True
-        
-        callback = SlackUpdate(
-            token="test_token",
-            channel="C123456",
-            ModelName="Test_Model",
-            export="png",
-            SendPlot=True,
-            verbose=0
-        )
-        
-        assert callback.ModelName == "Test_Model"
-        assert callback.export == "png"
-        assert callback.SendPlot == True
-        assert callback.verbose == 0
-        assert callback.n_epochs == 0
-        assert callback.train_loss == []
-        assert callback.train_acc == []
-        assert callback.valid_loss == []
-        assert callback.valid_acc == []
-    
-    @patch('slackker.callbacks.keras.checkker.check_internet')
-    @patch('slackker.callbacks.keras.checkker.slack_connect')
-    @patch('slackker.callbacks.keras.WebClient')
-    def test_slack_keras_init_with_all_formats(self, mock_webclient, mock_slack_connect, mock_check_internet):
-        """Test SlackUpdate initialization with different export formats"""
-        mock_check_internet.return_value = True
-        mock_slack_connect.return_value = True
-        
-        formats = ["png", "jpg", "pdf", "svg"]
-        for fmt in formats:
-            callback = SlackUpdate(
-                token="test_token",
-                channel="C123456",
-                ModelName="Test_Model",
-                export=fmt,
-                SendPlot=False
-            )
-            assert callback.export == fmt
-    
-    @patch('slackker.callbacks.keras.colors.prRed')
-    def test_slack_keras_init_no_token(self, mock_print_red):
-        """Test SlackUpdate initialization with None token"""
-        callback = SlackUpdate(
-            token=None,
-            channel="C123456",
-            ModelName="Test_Model"
-        )
-        mock_print_red.assert_called_once()
-    
-    @patch('slackker.callbacks.keras.checkker.check_internet')
-    @patch('slackker.callbacks.keras.checkker.slack_connect')
-    def test_slack_keras_init_no_internet(self, mock_slack_connect, mock_check_internet):
-        """Test SlackUpdate initialization without internet"""
-        mock_check_internet.return_value = False
-        mock_slack_connect.return_value = True
-        
-        callback = SlackUpdate(
-            token="test_token",
-            channel="C123456",
-            ModelName="Test_Model"
-        )
-        mock_check_internet.assert_called_once_with(url="www.slack.com", verbose=0)
-    
-    @patch('slackker.callbacks.keras.checkker.check_internet')
-    @patch('slackker.callbacks.keras.checkker.slack_connect')
-    @patch('slackker.callbacks.keras.WebClient')
-    def test_slack_keras_init_invalid_export_format(self, mock_webclient, mock_slack_connect, mock_check_internet):
-        """Test SlackUpdate initialization with invalid export format"""
-        mock_check_internet.return_value = True
-        mock_slack_connect.return_value = True
-        
-        # This should pass during init, validation happens in __init__
-        callback = SlackUpdate(
-            token="test_token",
-            channel="C123456",
-            ModelName="Test_Model",
-            export="png"
-        )
-        assert callback.export == "png"
+# ── Fixtures ──────────────────────────────────────────────────
+
+class MockClient(BaseClient):
+    """Concrete test client that records calls."""
+
+    def __init__(self, verbose=0, platform_name="mock"):
+        super().__init__(verbose=verbose)
+        self._platform_name = platform_name
+        self.messages = []
+        self.uploaded_files = []
+        self.uploaded_images = []
+
+    @property
+    def platform(self):
+        return self._platform_name
+
+    @property
+    def is_connected(self):
+        return True
+
+    async def send_message(self, text):
+        self.messages.append(text)
+
+    async def upload_file(self, filepath, comment=None):
+        self.uploaded_files.append((filepath, comment))
+
+    async def upload_image(self, filepath, comment=None):
+        self.uploaded_images.append((filepath, comment))
 
 
-class TestTelegramUpdateKerasInitialization:
-    """Test TelegramUpdate Keras callback initialization"""
-    
-    @patch('slackker.callbacks.keras.checkker.check_internet')
-    @patch('slackker.callbacks.keras.checkker.get_telegram_chat_id')
-    def test_telegram_keras_init_success(self, mock_get_chat_id, mock_check_internet):
-        """Test successful TelegramUpdate Keras callback initialization"""
-        mock_check_internet.return_value = True
-        mock_get_chat_id.return_value = "123456789"
-        
-        callback = TelegramUpdate(
-            token="test_token",
-            ModelName="Keras_NN",
-            export="png",
-            SendPlot=True,
-            verbose=1
-        )
-        
-        assert callback.token == "test_token"
-        assert callback.channel == "123456789"
-        assert callback.ModelName == "Keras_NN"
-        assert callback.export == "png"
-        assert callback.SendPlot == True
-        assert callback.verbose == 1
-        assert callback.n_epochs == 0
-    
-    @patch('slackker.callbacks.keras.checkker.check_internet')
-    @patch('slackker.callbacks.keras.checkker.get_telegram_chat_id')
-    def test_telegram_keras_init_default_params(self, mock_get_chat_id, mock_check_internet):
-        """Test TelegramUpdate initialization with default parameters"""
-        mock_check_internet.return_value = True
-        mock_get_chat_id.return_value = "123456789"
-        
-        callback = TelegramUpdate(
-            token="test_token",
-            ModelName="My_Model"
-        )
-        
-        assert callback.export == "png"  # Default
-        assert callback.SendPlot == False  # Default
-        assert callback.verbose == 0  # Default
-    
-    @patch('slackker.callbacks.keras.colors.prRed')
-    def test_telegram_keras_init_no_token(self, mock_print_red):
-        """Test TelegramUpdate initialization with None token"""
-        callback = TelegramUpdate(
-            token=None,
-            ModelName="Test_Model"
-        )
-        mock_print_red.assert_called_once()
-    
-    @patch('slackker.callbacks.keras.checkker.check_internet')
-    @patch('slackker.callbacks.keras.checkker.get_telegram_chat_id')
-    def test_telegram_keras_init_no_internet(self, mock_get_chat_id, mock_check_internet):
-        """Test TelegramUpdate initialization without internet"""
-        mock_check_internet.return_value = False
-        mock_get_chat_id.return_value = "123456789"
-        
-        callback = TelegramUpdate(
-            token="test_token",
-            ModelName="Test_Model"
-        )
-        mock_check_internet.assert_called_once_with(url="www.telegram.org", verbose=0)
+def _make_callback(platform="slack", verbose=0, send_plot=False, export="png"):
+    client = MockClient(verbose=verbose, platform_name=platform)
+    cb = KerasCallback(
+        client=client,
+        model_name="TestModel",
+        export=export,
+        send_plot=send_plot,
+    )
+    return cb, client
 
 
-class TestSlackUpdateKerasCallbacks:
-    """Test SlackUpdate Keras callback methods"""
-    
-    @patch('slackker.callbacks.keras.checkker.check_internet')
-    @patch('slackker.callbacks.keras.checkker.slack_connect')
-    @patch('slackker.callbacks.keras.WebClient')
-    @patch('slackker.callbacks.keras.functions.Slack.report_stats')
-    def test_on_train_begin(self, mock_report, mock_webclient, mock_slack_connect, mock_check_internet):
-        """Test on_train_begin callback method"""
-        mock_check_internet.return_value = True
-        mock_slack_connect.return_value = True
-        
-        callback = SlackUpdate(
-            token="test_token",
-            channel="C123456",
-            ModelName="Test_Model"
-        )
-        
-        callback.on_train_begin(logs={})
-        
-        mock_report.assert_called_once()
-        call_args = mock_report.call_args
-        message = call_args[1]['text']
-        assert "Test_Model" in message
-        assert "started at" in message
-    
-    @patch('slackker.callbacks.keras.checkker.check_internet')
-    @patch('slackker.callbacks.keras.checkker.slack_connect')
-    @patch('slackker.callbacks.keras.WebClient')
-    @patch('slackker.callbacks.keras.functions.Slack.report_stats')
-    @patch('slackker.callbacks.keras.checkker.check_internet_epoch_end')
-    def test_on_epoch_end(self, mock_check_epoch, mock_report, mock_webclient, mock_slack_connect, mock_check_internet):
-        """Test on_epoch_end callback method"""
-        mock_check_internet.return_value = True
-        mock_slack_connect.return_value = True
-        mock_check_epoch.return_value = True
-        
-        callback = SlackUpdate(
-            token="test_token",
-            channel="C123456",
-            ModelName="Test_Model"
-        )
-        
-        logs = {
-            'accuracy': 0.85,
-            'loss': 0.45,
-            'val_accuracy': 0.80,
-            'val_loss': 0.50
-        }
-        
-        callback.on_epoch_end(batch=0, logs=logs)
-        
-        assert callback.n_epochs == 1
-        assert len(callback.train_loss) == 1
-        assert len(callback.train_acc) == 1
-        assert len(callback.valid_loss) == 1
-        assert len(callback.valid_acc) == 1
-        
-        # Verify report was called
-        assert mock_report.called
-    
-    @patch('slackker.callbacks.keras.checkker.check_internet')
-    @patch('slackker.callbacks.keras.checkker.slack_connect')
-    @patch('slackker.callbacks.keras.WebClient')
-    @patch('slackker.callbacks.keras.functions.Slack.report_stats')
-    @patch('slackker.callbacks.keras.checkker.check_internet_epoch_end')
-    def test_multiple_epochs(self, mock_check_epoch, mock_report, mock_webclient, mock_slack_connect, mock_check_internet):
-        """Test multiple epochs tracking"""
-        mock_check_internet.return_value = True
-        mock_slack_connect.return_value = True
-        mock_check_epoch.return_value = True
-        
-        callback = SlackUpdate(
-            token="test_token",
-            channel="C123456",
-            ModelName="Test_Model"
-        )
-        
-        # Simulate 3 epochs
+# ── KerasCallback initialization ──────────────────────────────
+
+class TestKerasCallbackInit:
+    def test_init_stores_attributes(self):
+        cb, _ = _make_callback()
+        assert cb.model_name == "TestModel"
+        assert cb.export == "png"
+        assert cb.send_plot is False
+        assert cb.n_epochs == 0
+        assert cb.train_loss == []
+        assert cb.train_acc == []
+
+    def test_init_rejects_bad_format(self):
+        m = MockClient()
+        with pytest.raises(ValueError, match="Unsupported export format"):
+            KerasCallback(client=m, model_name="M", export="bmp")
+
+
+# ── on_train_begin ────────────────────────────────────────────
+
+class TestOnTrainBegin:
+    def test_posts_training_start(self):
+        cb, client = _make_callback()
+        cb.on_train_begin()
+        assert len(client.messages) == 1
+        assert "TestModel" in client.messages[0]
+        assert "started at" in client.messages[0]
+
+
+# ── on_epoch_end ──────────────────────────────────────────────
+
+class TestOnEpochEnd:
+    @patch("slackker.callbacks.keras.network.check_connection_quick", new_callable=AsyncMock, return_value=True)
+    def test_tracks_metrics_and_reports(self, mock_check):
+        cb, client = _make_callback()
+        logs = {"accuracy": 0.85, "loss": 0.45, "val_accuracy": 0.80, "val_loss": 0.50}
+        cb.on_epoch_end(batch=0, logs=logs)
+
+        assert cb.n_epochs == 1
+        assert len(cb.train_loss) == 1
+        assert len(cb.valid_loss) == 1
+        assert len(client.messages) == 1
+        assert "Epoch: 0" in client.messages[0]
+
+    @patch("slackker.callbacks.keras.network.check_connection_quick", new_callable=AsyncMock, return_value=False)
+    def test_skips_report_without_internet(self, mock_check):
+        cb, client = _make_callback()
+        logs = {"accuracy": 0.85, "loss": 0.45, "val_accuracy": 0.80, "val_loss": 0.50}
+        cb.on_epoch_end(batch=0, logs=logs)
+
+        assert cb.n_epochs == 1
+        assert len(cb.train_loss) == 1
+        assert len(client.messages) == 0
+
+    @patch("slackker.callbacks.keras.network.check_connection_quick", new_callable=AsyncMock, return_value=True)
+    def test_multiple_epochs(self, mock_check):
+        cb, client = _make_callback()
         epochs_logs = [
-            {'accuracy': 0.70, 'loss': 0.60, 'val_accuracy': 0.65, 'val_loss': 0.65},
-            {'accuracy': 0.80, 'loss': 0.45, 'val_accuracy': 0.75, 'val_loss': 0.50},
-            {'accuracy': 0.85, 'loss': 0.35, 'val_accuracy': 0.82, 'val_loss': 0.40},
+            {"accuracy": 0.70, "loss": 0.60, "val_accuracy": 0.65, "val_loss": 0.65},
+            {"accuracy": 0.80, "loss": 0.45, "val_accuracy": 0.75, "val_loss": 0.50},
+            {"accuracy": 0.85, "loss": 0.35, "val_accuracy": 0.82, "val_loss": 0.40},
         ]
-        
         for i, logs in enumerate(epochs_logs):
-            callback.on_epoch_end(batch=i, logs=logs)
-        
-        assert callback.n_epochs == 3
-        assert len(callback.train_loss) == 3
-        assert len(callback.valid_acc) == 3
-        assert callback.train_loss[-1] == 0.35
-        assert callback.valid_acc[-1] == 0.82
-    
-    @patch('slackker.callbacks.keras.checkker.check_internet')
-    @patch('slackker.callbacks.keras.checkker.slack_connect')
-    @patch('slackker.callbacks.keras.WebClient')
-    @patch('slackker.callbacks.keras.functions.Slack.report_stats')
-    @patch('slackker.callbacks.keras.functions.Slack.keras_plot_history')
-    def test_on_train_end(self, mock_plot, mock_report, mock_webclient, mock_slack_connect, mock_check_internet):
-        """Test on_train_end callback method"""
-        mock_check_internet.return_value = True
-        mock_slack_connect.return_value = True
-        
-        callback = SlackUpdate(
-            token="test_token",
-            channel="C123456",
-            ModelName="Test_Model",
-            export="png",
-            SendPlot=True
-        )
-        
-        # Simulate training history
-        callback.train_loss = [0.60, 0.45, 0.35]
-        callback.train_acc = [0.70, 0.80, 0.85]
-        callback.valid_loss = [0.65, 0.50, 0.40]
-        callback.valid_acc = [0.65, 0.75, 0.82]
-        callback.n_epochs = 3
-        
-        callback.on_train_end(logs={})
-        
-        # Verify report was called with best epoch info
-        assert mock_report.call_count >= 2
-        
-        # Verify plot function was called
-        mock_plot.assert_called_once()
-        plot_call_args = mock_plot.call_args
-        training_logs = plot_call_args[1]['training_logs']
-        assert 'train_loss' in training_logs
-        assert 'train_acc' in training_logs
-        assert 'val_loss' in training_logs
-        assert 'val_acc' in training_logs
-    
-    @patch('slackker.callbacks.keras.checkker.check_internet')
-    @patch('slackker.callbacks.keras.checkker.slack_connect')
-    @patch('slackker.callbacks.keras.WebClient')
-    @patch('slackker.callbacks.keras.functions.Slack.report_stats')
-    @patch('slackker.callbacks.keras.functions.Slack.keras_plot_history')
-    def test_best_epoch_calculation(self, mock_plot, mock_report, mock_webclient, mock_slack_connect, mock_check_internet):
-        """Test best epoch calculation in on_train_end"""
-        mock_check_internet.return_value = True
-        mock_slack_connect.return_value = True
-        
-        callback = SlackUpdate(
-            token="test_token",
-            channel="C123456",
-            ModelName="Test_Model"
-        )
-        
-        # Set training logs with known best epoch
-        callback.train_loss = [0.60, 0.45, 0.35, 0.40]  # Best at index 2
-        callback.train_acc = [0.70, 0.80, 0.85, 0.84]
-        callback.valid_loss = [0.65, 0.50, 0.38, 0.42]  # Best at index 2
-        callback.valid_acc = [0.65, 0.75, 0.82, 0.80]
-        callback.n_epochs = 4
-        
-        callback.on_train_end(logs={})
-        
-        # Check that the best epoch (2) was identified and reported
-        call_args_list = mock_report.call_args_list
-        # Find the call with best epoch info
-        found_best_epoch = False
-        for call_obj in call_args_list:
-            message = call_obj[1]['text']
-            if "Best epoch was 2" in message:
-                found_best_epoch = True
-                break
-        
-        assert found_best_epoch, "Best epoch information not found in report calls"
-    
-    @patch('slackker.callbacks.keras.checkker.check_internet')
-    @patch('slackker.callbacks.keras.checkker.slack_connect')
-    @patch('slackker.callbacks.keras.WebClient')
-    @patch('slackker.callbacks.keras.functions.Slack.report_stats')
-    @patch('slackker.callbacks.keras.checkker.check_internet_epoch_end')
-    def test_epoch_end_no_internet(self, mock_check_epoch, mock_report, mock_webclient, mock_slack_connect, mock_check_internet):
-        """Test epoch end callback when internet is unavailable"""
-        mock_check_internet.return_value = True
-        mock_slack_connect.return_value = True
-        mock_check_epoch.return_value = False  # No internet
-        
-        callback = SlackUpdate(
-            token="test_token",
-            channel="C123456",
-            ModelName="Test_Model"
-        )
-        
-        logs = {
-            'accuracy': 0.85,
-            'loss': 0.45,
-            'val_accuracy': 0.80,
-            'val_loss': 0.50
-        }
-        
-        callback.on_epoch_end(batch=0, logs=logs)
-        
-        # Logs should still be recorded even without internet
-        assert callback.n_epochs == 1
-        assert len(callback.train_loss) == 1
+            cb.on_epoch_end(batch=i, logs=logs)
+
+        assert cb.n_epochs == 3
+        assert len(cb.train_loss) == 3
+        assert cb.train_loss[-1] == 0.35
+        assert cb.valid_acc[-1] == 0.82
 
 
-class TestTelegramUpdateKerasCallbacks:
-    """Test TelegramUpdate Keras callback methods"""
-    
-    @patch('slackker.callbacks.keras.checkker.check_internet')
-    @patch('slackker.callbacks.keras.checkker.get_telegram_chat_id')
-    @patch('slackker.callbacks.keras.functions.Telegram.report_stats')
-    def test_telegram_on_train_begin(self, mock_report, mock_get_chat_id, mock_check_internet):
-        """Test Telegram on_train_begin callback"""
-        mock_check_internet.return_value = True
-        mock_get_chat_id.return_value = "123456789"
-        
-        callback = TelegramUpdate(
-            token="test_token",
-            ModelName="Keras_NN"
-        )
-        
-        callback.on_train_begin(logs={})
-        
-        mock_report.assert_called_once()
-        call_args = mock_report.call_args
-        message = call_args[1]['text']
-        assert "Keras_NN" in message
-        assert "started at" in message
-    
-    @patch('slackker.callbacks.keras.checkker.check_internet')
-    @patch('slackker.callbacks.keras.checkker.get_telegram_chat_id')
-    @patch('slackker.callbacks.keras.functions.Telegram.report_stats')
-    @patch('slackker.callbacks.keras.checkker.check_internet_epoch_end')
-    def test_telegram_on_epoch_end(self, mock_check_epoch, mock_report, mock_get_chat_id, mock_check_internet):
-        """Test Telegram on_epoch_end callback"""
-        mock_check_internet.return_value = True
-        mock_get_chat_id.return_value = "123456789"
-        mock_check_epoch.return_value = True
-        
-        callback = TelegramUpdate(
-            token="test_token",
-            ModelName="Keras_NN"
-        )
-        
-        logs = {
-            'accuracy': 0.85,
-            'loss': 0.45,
-            'val_accuracy': 0.80,
-            'val_loss': 0.50
-        }
-        
-        callback.on_epoch_end(batch=0, logs=logs)
-        
-        assert callback.n_epochs == 1
-        assert mock_report.called
-    
-    @patch('slackker.callbacks.keras.checkker.check_internet')
-    @patch('slackker.callbacks.keras.checkker.get_telegram_chat_id')
-    @patch('slackker.callbacks.keras.functions.Telegram.report_stats')
-    @patch('slackker.callbacks.keras.functions.Telegram.keras_plot_history')
-    def test_telegram_on_train_end(self, mock_plot, mock_report, mock_get_chat_id, mock_check_internet):
-        """Test Telegram on_train_end callback"""
-        mock_check_internet.return_value = True
-        mock_get_chat_id.return_value = "123456789"
-        
-        callback = TelegramUpdate(
-            token="test_token",
-            ModelName="Keras_NN",
-            export="png",
-            SendPlot=True
-        )
-        
-        callback.train_loss = [0.60, 0.45, 0.35]
-        callback.train_acc = [0.70, 0.80, 0.85]
-        callback.valid_loss = [0.65, 0.50, 0.40]
-        callback.valid_acc = [0.65, 0.75, 0.82]
-        callback.n_epochs = 3
-        
-        callback.on_train_end(logs={})
-        
-        assert mock_report.call_count >= 2
-        mock_plot.assert_called_once()
-    
-    @patch('slackker.callbacks.keras.checkker.check_internet')
-    @patch('slackker.callbacks.keras.checkker.get_telegram_chat_id')
-    @patch('slackker.callbacks.keras.functions.Telegram.report_stats')
-    @patch('slackker.callbacks.keras.checkker.check_internet_epoch_end')
-    def test_telegram_multiple_epochs(self, mock_check_epoch, mock_report, mock_get_chat_id, mock_check_internet):
-        """Test Telegram callback with multiple epochs"""
-        mock_check_internet.return_value = True
-        mock_get_chat_id.return_value = "123456789"
-        mock_check_epoch.return_value = True
-        
-        callback = TelegramUpdate(
-            token="test_token",
-            ModelName="Keras_NN"
-        )
-        
-        epochs_logs = [
-            {'accuracy': 0.70, 'loss': 0.60, 'val_accuracy': 0.65, 'val_loss': 0.65},
-            {'accuracy': 0.80, 'loss': 0.45, 'val_accuracy': 0.75, 'val_loss': 0.50},
-            {'accuracy': 0.85, 'loss': 0.35, 'val_accuracy': 0.82, 'val_loss': 0.40},
-        ]
-        
-        for i, logs in enumerate(epochs_logs):
-            callback.on_epoch_end(batch=i, logs=logs)
-        
-        assert callback.n_epochs == 3
+# ── on_train_end ──────────────────────────────────────────────
+
+class TestOnTrainEnd:
+    def test_reports_best_epoch(self):
+        cb, client = _make_callback()
+        cb.train_loss = [0.60, 0.45, 0.35, 0.40]
+        cb.train_acc = [0.70, 0.80, 0.85, 0.84]
+        cb.valid_loss = [0.65, 0.50, 0.38, 0.42]
+        cb.valid_acc = [0.65, 0.75, 0.82, 0.80]
+        cb.n_epochs = 4
+
+        cb.on_train_end()
+
+        found_best = any("Best epoch was 2" in m for m in client.messages)
+        assert found_best
+
+    @patch("slackker.callbacks.keras.plotting.generate_and_get_plots", return_value=["/tmp/loss.png", "/tmp/acc.png"])
+    def test_uploads_plots_when_enabled(self, mock_plots):
+        cb, client = _make_callback(send_plot=True)
+        cb.train_loss = [0.6, 0.4]
+        cb.train_acc = [0.7, 0.8]
+        cb.valid_loss = [0.65, 0.45]
+        cb.valid_acc = [0.65, 0.78]
+        cb.n_epochs = 2
+
+        cb.on_train_end()
+
+        assert len(client.uploaded_images) == 2
+        mock_plots.assert_called_once()
+
+    def test_empty_valid_loss_skips_best(self):
+        cb, client = _make_callback()
+        cb.n_epochs = 0
+        cb.on_train_end()
+        # No messages about best epoch when no data
+        assert not any("Best epoch" in m for m in client.messages)
 
 
-class TestKerasCallbackIntegration:
-    """Integration tests for Keras callbacks"""
-    
-    @patch('slackker.callbacks.keras.checkker.check_internet')
-    @patch('slackker.callbacks.keras.checkker.slack_connect')
-    @patch('slackker.callbacks.keras.WebClient')
-    @patch('slackker.callbacks.keras.functions.Slack.report_stats')
-    @patch('slackker.callbacks.keras.checkker.check_internet_epoch_end')
-    @patch('slackker.callbacks.keras.functions.Slack.keras_plot_history')
-    def test_slack_complete_training_workflow(self, mock_plot, mock_check_epoch, mock_report, 
-                                              mock_webclient, mock_slack_connect, mock_check_internet):
-        """Test complete Slack training workflow"""
-        mock_check_internet.return_value = True
-        mock_slack_connect.return_value = True
-        mock_check_epoch.return_value = True
-        
-        callback = SlackUpdate(
-            token="xoxb-test",
-            channel="C123456",
-            ModelName="Keras_NN",
-            export="png",
-            SendPlot=True
-        )
-        
-        # Training begins
-        callback.on_train_begin(logs={})
-        
-        # Simulate 5 epochs
-        for epoch in range(5):
-            logs = {
-                'accuracy': 0.70 + epoch * 0.03,
-                'loss': 0.60 - epoch * 0.05,
-                'val_accuracy': 0.65 + epoch * 0.03,
-                'val_loss': 0.65 - epoch * 0.05
-            }
-            callback.on_epoch_end(batch=epoch, logs=logs)
-        
-        # Training ends
-        callback.on_train_end(logs={})
-        
-        # Verify workflow
-        assert callback.n_epochs == 5
-        assert mock_report.call_count >= 2  # Begin + end
-        mock_plot.assert_called_once()
-    
-    @patch('slackker.callbacks.keras.checkker.check_internet')
-    @patch('slackker.callbacks.keras.checkker.get_telegram_chat_id')
-    @patch('slackker.callbacks.keras.functions.Telegram.report_stats')
-    @patch('slackker.callbacks.keras.checkker.check_internet_epoch_end')
-    @patch('slackker.callbacks.keras.functions.Telegram.keras_plot_history')
-    def test_telegram_complete_training_workflow(self, mock_plot, mock_check_epoch, mock_report, 
-                                                 mock_get_chat_id, mock_check_internet):
-        """Test complete Telegram training workflow"""
-        mock_check_internet.return_value = True
-        mock_get_chat_id.return_value = "123456789"
-        mock_check_epoch.return_value = True
-        
-        callback = TelegramUpdate(
-            token="6703340847:AAECWu8qLPTIRMDGjXjzwT5UbK_9P13WdK8",
-            ModelName="Keras_NN",
-            export="png",
-            SendPlot=True
-        )
-        
-        # Training begins
-        callback.on_train_begin(logs={})
-        
-        # Simulate epochs
-        for epoch in range(3):
-            logs = {
-                'accuracy': 0.70 + epoch * 0.05,
-                'loss': 0.60 - epoch * 0.1,
-                'val_accuracy': 0.65 + epoch * 0.05,
-                'val_loss': 0.65 - epoch * 0.1
-            }
-            callback.on_epoch_end(batch=epoch, logs=logs)
-        
-        # Training ends
-        callback.on_train_end(logs={})
-        
-        assert callback.n_epochs == 3
-        mock_plot.assert_called_once()
+# ── Log ordering ──────────────────────────────────────────────
 
-
-class TestKerasCallbackEdgeCases:
-    """Test edge cases for Keras callbacks"""
-    
-    @patch('slackker.callbacks.keras.checkker.check_internet')
-    @patch('slackker.callbacks.keras.checkker.slack_connect')
-    @patch('slackker.callbacks.keras.WebClient')
-    @patch('slackker.callbacks.keras.functions.Slack.report_stats')
-    def test_slack_single_epoch(self, mock_report, mock_webclient, mock_slack_connect, mock_check_internet):
-        """Test Slack callback with single epoch"""
-        mock_check_internet.return_value = True
-        mock_slack_connect.return_value = True
-        
-        callback = SlackUpdate(
-            token="test_token",
-            channel="C123456",
-            ModelName="Test_Model"
-        )
-        
-        logs = {
-            'accuracy': 0.85,
-            'loss': 0.45,
-            'val_accuracy': 0.80,
-            'val_loss': 0.50
-        }
-        
-        callback.on_epoch_end(batch=0, logs=logs)
-        assert callback.n_epochs == 1
-    
-    @patch('slackker.callbacks.keras.checkker.check_internet')
-    @patch('slackker.callbacks.keras.checkker.slack_connect')
-    @patch('slackker.callbacks.keras.WebClient')
-    @patch('slackker.callbacks.keras.functions.Slack.report_stats')
-    @patch('slackker.callbacks.keras.functions.Slack.keras_plot_history')
-    def test_slack_logs_ordering(self, mock_plot, mock_report, mock_webclient, mock_slack_connect, mock_check_internet):
-        """Test that logs are stored in correct order"""
-        mock_check_internet.return_value = True
-        mock_slack_connect.return_value = True
-        
-        callback = SlackUpdate(
-            token="test_token",
-            channel="C123456",
-            ModelName="Test_Model"
-        )
-        
-        # Create multiple epochs with distinguishable values
+class TestLogOrdering:
+    @patch("slackker.callbacks.keras.network.check_connection_quick", new_callable=AsyncMock, return_value=True)
+    def test_logs_stored_in_order(self, mock_check):
+        cb, _ = _make_callback()
         for i in range(3):
             logs = {
-                'accuracy': 0.5 + i * 0.1,
-                'loss': 0.9 - i * 0.1,
-                'val_accuracy': 0.4 + i * 0.1,
-                'val_loss': 1.0 - i * 0.1
+                "accuracy": 0.5 + i * 0.1,
+                "loss": 0.9 - i * 0.1,
+                "val_accuracy": 0.4 + i * 0.1,
+                "val_loss": 1.0 - i * 0.1,
             }
-            callback.on_epoch_end(batch=i, logs=logs)
-        
-        # Verify order is maintained
-        assert callback.train_acc == pytest.approx([0.5, 0.6, 0.7])
-        assert callback.train_loss == pytest.approx([0.9, 0.8, 0.7])
-        assert callback.valid_acc == pytest.approx([0.4, 0.5, 0.6])
-        assert callback.valid_loss == pytest.approx([1.0, 0.9, 0.8])
-    
-    @patch('slackker.callbacks.keras.checkker.check_internet')
-    @patch('slackker.callbacks.keras.checkker.get_telegram_chat_id')
-    @patch('slackker.callbacks.keras.functions.Telegram.report_stats')
-    @patch('slackker.callbacks.keras.functions.Telegram.keras_plot_history')
-    def test_telegram_empty_training(self, mock_plot, mock_report, mock_get_chat_id, mock_check_internet):
-        """Test Telegram callback with no epochs"""
-        mock_check_internet.return_value = True
-        mock_get_chat_id.return_value = "123456789"
-        
-        callback = TelegramUpdate(
-            token="test_token",
-            ModelName="Test_Model"
-        )
-        
-        # Call on_train_end without any epochs
-        with pytest.raises(ValueError):
-            callback.on_train_end(logs={})
+            cb.on_epoch_end(batch=i, logs=logs)
+
+        assert cb.train_acc == pytest.approx([0.5, 0.6, 0.7])
+        assert cb.train_loss == pytest.approx([0.9, 0.8, 0.7])
+        assert cb.valid_acc == pytest.approx([0.4, 0.5, 0.6])
+        assert cb.valid_loss == pytest.approx([1.0, 0.9, 0.8])
 
 
-class TestKerasCallbackVerbosity:
-    """Test verbose logging for Keras callbacks"""
-    
-    @patch('slackker.callbacks.keras.checkker.check_internet')
-    @patch('slackker.callbacks.keras.checkker.slack_connect')
-    @patch('slackker.callbacks.keras.WebClient')
-    @patch('slackker.callbacks.keras.functions.Slack.report_stats')
-    def test_slack_verbose_level_0(self, mock_report, mock_webclient, mock_slack_connect, mock_check_internet):
-        """Test Slack callback with verbose=0 (silent)"""
-        mock_check_internet.return_value = True
-        mock_slack_connect.return_value = True
-        
-        callback = SlackUpdate(
-            token="test_token",
-            channel="C123456",
-            ModelName="Test_Model",
-            verbose=0
-        )
-        
-        callback.on_train_begin(logs={})
-        assert mock_report.called
-    
-    @patch('slackker.callbacks.keras.checkker.check_internet')
-    @patch('slackker.callbacks.keras.checkker.slack_connect')
-    @patch('slackker.callbacks.keras.WebClient')
-    @patch('slackker.callbacks.keras.functions.Slack.report_stats')
-    def test_slack_verbose_level_2(self, mock_report, mock_webclient, mock_slack_connect, mock_check_internet):
-        """Test Slack callback with verbose=2 (debug)"""
-        mock_check_internet.return_value = True
-        mock_slack_connect.return_value = True
-        
-        callback = SlackUpdate(
-            token="test_token",
-            channel="C123456",
-            ModelName="Test_Model",
-            verbose=2
-        )
-        
-        callback.on_train_begin(logs={})
-        # Verify callback still works with higher verbosity
-        call_args = mock_report.call_args
-        assert call_args[1]['verbose'] == 2
-    
-    @patch('slackker.callbacks.keras.checkker.check_internet')
-    @patch('slackker.callbacks.keras.checkker.get_telegram_chat_id')
-    @patch('slackker.callbacks.keras.functions.Telegram.report_stats')
-    def test_telegram_verbose_level_1(self, mock_report, mock_get_chat_id, mock_check_internet):
-        """Test Telegram callback with verbose=1 (info)"""
-        mock_check_internet.return_value = True
-        mock_get_chat_id.return_value = "123456789"
-        
-        callback = TelegramUpdate(
-            token="test_token",
-            ModelName="Test_Model",
-            verbose=1
-        )
-        
-        callback.on_train_begin(logs={})
-        call_args = mock_report.call_args
-        assert call_args[1]['verbose'] == 1
+# ── Complete workflow ─────────────────────────────────────────
+
+class TestCompleteWorkflow:
+    @patch("slackker.callbacks.keras.network.check_connection_quick", new_callable=AsyncMock, return_value=True)
+    @patch("slackker.callbacks.keras.plotting.generate_and_get_plots", return_value=["/tmp/loss.png"])
+    def test_full_training(self, mock_plots, mock_check):
+        cb, client = _make_callback(send_plot=True)
+
+        cb.on_train_begin()
+        for epoch in range(5):
+            logs = {
+                "accuracy": 0.70 + epoch * 0.03,
+                "loss": 0.60 - epoch * 0.05,
+                "val_accuracy": 0.65 + epoch * 0.03,
+                "val_loss": 0.65 - epoch * 0.05,
+            }
+            cb.on_epoch_end(batch=epoch, logs=logs)
+        cb.on_train_end()
+
+        assert cb.n_epochs == 5
+        assert len(client.messages) >= 7  # 1 begin + 5 epochs + 2 end summaries
+
+
+# ── Backward-compat shim tests ───────────────────────────────
+
+class TestSlackUpdateShim:
+    @patch("slackker.callbacks.keras.SlackClient")
+    def test_init_deprecation_warning(self, mock_cls):
+        mock_client = MockClient()
+        mock_client.connect = AsyncMock(return_value=True)
+        mock_client._client = MagicMock()
+        mock_cls.return_value = mock_client
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            cb = SlackUpdate(token="xoxb-test", channel="C123", ModelName="M")
+            assert any(issubclass(x.category, DeprecationWarning) for x in w)
+
+    @patch("slackker.callbacks.keras.SlackClient")
+    def test_shim_preserves_old_attrs(self, mock_cls):
+        mock_client = MockClient()
+        mock_client.connect = AsyncMock(return_value=True)
+        mock_client._client = MagicMock()
+        mock_cls.return_value = mock_client
+
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            cb = SlackUpdate(token="xoxb-test", channel="C123", ModelName="M", SendPlot=True, verbose=2)
+
+        assert cb.ModelName == "M"
+        assert cb.SendPlot is True
+        assert cb.verbose == 2
+
+    def test_no_token(self):
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            cb = SlackUpdate(token=None, channel="C123", ModelName="M")
+        assert not hasattr(cb, "client")
+
+
+class TestTelegramUpdateShim:
+    @patch("slackker.callbacks.keras.TelegramClient")
+    def test_init_deprecation_warning(self, mock_cls):
+        mock_client = MockClient()
+        mock_client.connect = AsyncMock(return_value=True)
+        mock_client.chat_id = "99999"
+        mock_cls.return_value = mock_client
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            cb = TelegramUpdate(token="123:ABC", ModelName="M")
+            assert any(issubclass(x.category, DeprecationWarning) for x in w)
+
+    def test_no_token(self):
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            cb = TelegramUpdate(token=None, ModelName="M")
+        assert not hasattr(cb, "client")
 
 
 class TestKerasCallbackMessageFormatting:
-    """Test message formatting in Keras callbacks"""
-    
-    @patch('slackker.callbacks.keras.checkker.check_internet')
-    @patch('slackker.callbacks.keras.checkker.slack_connect')
-    @patch('slackker.callbacks.keras.WebClient')
-    @patch('slackker.callbacks.keras.functions.Slack.report_stats')
-    @patch('slackker.callbacks.keras.checkker.check_internet_epoch_end')
-    def test_epoch_message_format(self, mock_check_epoch, mock_report, mock_webclient, 
-                                   mock_slack_connect, mock_check_internet):
-        """Test epoch message formatting"""
-        mock_check_internet.return_value = True
-        mock_slack_connect.return_value = True
-        mock_check_epoch.return_value = True
-        
-        callback = SlackUpdate(
-            token="test_token",
-            channel="C123456",
-            ModelName="Test_Model"
-        )
-        
+    """Test message formatting in Keras callbacks using MockClient."""
+
+    @patch("slackker.callbacks.keras.network.check_connection_quick", new_callable=AsyncMock, return_value=True)
+    def test_epoch_message_format(self, mock_check):
+        cb, client = _make_callback()
         logs = {
-            'accuracy': 0.8234,
-            'loss': 0.4567,
-            'val_accuracy': 0.7956,
-            'val_loss': 0.5123
+            "accuracy": 0.8234,
+            "loss": 0.4567,
+            "val_accuracy": 0.7956,
+            "val_loss": 0.5123,
         }
-        
-        callback.on_epoch_end(batch=0, logs=logs)
-        
-        call_args = mock_report.call_args
-        message = call_args[1]['text']
-        
-        # Verify message contains expected information
+        cb.on_epoch_end(batch=0, logs=logs)
+
+        assert len(client.messages) == 1
+        message = client.messages[0]
         assert "Epoch: 0" in message
         assert "Training Loss:" in message
         assert "Validation Loss:" in message
-    
-    @patch('slackker.callbacks.keras.checkker.check_internet')
-    @patch('slackker.callbacks.keras.checkker.slack_connect')
-    @patch('slackker.callbacks.keras.WebClient')
-    @patch('slackker.callbacks.keras.functions.Slack.report_stats')
-    @patch('slackker.callbacks.keras.functions.Slack.keras_plot_history')
-    def test_train_end_message_format(self, mock_plot, mock_report, mock_webclient, 
-                                       mock_slack_connect, mock_check_internet):
-        """Test train end message formatting"""
-        mock_check_internet.return_value = True
-        mock_slack_connect.return_value = True
-        
-        callback = SlackUpdate(
-            token="test_token",
-            channel="C123456",
-            ModelName="Test_Model"
-        )
-        
-        callback.train_loss = [0.60, 0.45, 0.35]
-        callback.train_acc = [0.70, 0.80, 0.85]
-        callback.valid_loss = [0.65, 0.50, 0.40]
-        callback.valid_acc = [0.65, 0.75, 0.82]
-        callback.n_epochs = 3
-        
-        callback.on_train_end(logs={})
-        
-        # Verify messages contain training summary
-        call_args_list = mock_report.call_args_list
-        messages = [call_obj[1]['text'] for call_obj in call_args_list]
-        
-        # Should have at least 2 messages
-        assert len(messages) >= 2
-        # One should mention epochs
-        assert any("3 epochs" in msg for msg in messages)
+
+    @patch("slackker.callbacks.keras.plotting.generate_and_get_plots", return_value=["loss.png"])
+    def test_train_end_message_format(self, mock_plots):
+        cb, client = _make_callback(send_plot=True)
+        cb.train_loss = [0.60, 0.45, 0.35]
+        cb.train_acc = [0.70, 0.80, 0.85]
+        cb.valid_loss = [0.65, 0.50, 0.40]
+        cb.valid_acc = [0.65, 0.75, 0.82]
+        cb.n_epochs = 3
+
+        cb.on_train_end()
+
+        assert len(client.messages) >= 2
+        assert any("3 epochs" in m for m in client.messages)
 
 
 class TestKerasCallbackAdditionalBranches:
     """Extra branch coverage for init and lifecycle error paths."""
 
-    @patch('slackker.callbacks.keras.checkker.check_internet')
-    @patch('slackker.callbacks.keras.checkker.slack_connect')
-    @patch('slackker.callbacks.keras.WebClient')
-    def test_slack_init_export_none_raises(self, mock_webclient, mock_slack_connect, mock_check_internet):
-        mock_check_internet.return_value = True
-        mock_slack_connect.return_value = True
+    def test_init_export_none_raises(self):
+        m = MockClient()
+        with pytest.raises(ValueError, match="Unsupported export format"):
+            KerasCallback(client=m, model_name="M", export=None)
 
-        with pytest.raises(argparse.ArgumentTypeError):
-            SlackUpdate(
-                token="test_token",
-                channel="C123456",
-                ModelName="Test_Model",
-                export=None,
-            )
+    @patch("slackker.callbacks.keras.network.check_connection_quick", new_callable=AsyncMock, return_value=True)
+    def test_on_epoch_end_incomplete_logs_skips_tracking(self, mock_check):
+        cb, client = _make_callback()
+        cb.on_epoch_end(batch=0, logs={"accuracy": 0.8, "loss": 0.2})
+        # With < 4 log values, metrics are not tracked but epoch still counts
+        assert cb.n_epochs == 1
+        assert cb.train_loss == []
 
-    @patch('slackker.callbacks.keras.checkker.check_internet')
-    @patch('slackker.callbacks.keras.checkker.get_telegram_chat_id')
-    def test_telegram_init_export_none_raises(self, mock_get_chat_id, mock_check_internet):
-        mock_check_internet.return_value = True
-        mock_get_chat_id.return_value = "123456789"
-
-        with pytest.raises(argparse.ArgumentTypeError):
-            TelegramUpdate(
-                token="test_token",
-                ModelName="Test_Model",
-                export=None,
-            )
-
-    @patch('slackker.callbacks.keras.checkker.check_internet')
-    @patch('slackker.callbacks.keras.checkker.slack_connect')
-    @patch('slackker.callbacks.keras.WebClient')
-    @patch('slackker.callbacks.keras.checkker.check_internet_epoch_end')
-    @patch('slackker.callbacks.keras.functions.Slack.report_stats')
-    def test_slack_on_epoch_end_incomplete_logs_raises(
-        self, mock_report, mock_check_epoch, mock_webclient, mock_slack_connect, mock_check_internet
-    ):
-        mock_check_internet.return_value = True
-        mock_slack_connect.return_value = True
-        mock_check_epoch.return_value = True
-
-        callback = SlackUpdate(token="test_token", channel="C123456", ModelName="Test_Model")
-
-        with pytest.raises(IndexError):
-            callback.on_epoch_end(batch=0, logs={'accuracy': 0.8, 'loss': 0.2})
-
-    @patch('slackker.callbacks.keras.checkker.check_internet')
-    @patch('slackker.callbacks.keras.checkker.get_telegram_chat_id')
-    @patch('slackker.callbacks.keras.checkker.check_internet_epoch_end')
-    @patch('slackker.callbacks.keras.functions.Telegram.report_stats')
-    def test_telegram_on_epoch_end_no_internet_still_tracks(
-        self, mock_report, mock_check_epoch, mock_get_chat_id, mock_check_internet
-    ):
-        mock_check_internet.return_value = True
-        mock_get_chat_id.return_value = "123456789"
-        mock_check_epoch.return_value = False
-
-        callback = TelegramUpdate(token="test_token", ModelName="Test_Model")
+    @patch("slackker.callbacks.keras.network.check_connection_quick", new_callable=AsyncMock, return_value=False)
+    def test_on_epoch_end_no_internet_still_tracks(self, mock_check):
+        cb, client = _make_callback()
         logs = {
-            'accuracy': 0.85,
-            'loss': 0.45,
-            'val_accuracy': 0.80,
-            'val_loss': 0.50,
+            "accuracy": 0.85,
+            "loss": 0.45,
+            "val_accuracy": 0.80,
+            "val_loss": 0.50,
         }
+        cb.on_epoch_end(batch=0, logs=logs)
 
-        callback.on_epoch_end(batch=0, logs=logs)
+        assert cb.n_epochs == 1
+        assert cb.valid_loss == [0.50]
+        assert len(client.messages) == 0
 
-        assert callback.n_epochs == 1
-        assert callback.valid_loss == [0.50]
-        mock_report.assert_not_called()
+    @patch("slackker.callbacks.keras.plotting.generate_and_get_plots", return_value=["loss.png"])
+    def test_train_end_message_contains_accuracy_percent(self, mock_plots):
+        cb, client = _make_callback(send_plot=True)
+        cb.train_loss = [0.60, 0.45, 0.35]
+        cb.train_acc = [0.70, 0.80, 0.85]
+        cb.valid_loss = [0.65, 0.50, 0.40]
+        cb.valid_acc = [0.65, 0.75, 0.82]
+        cb.n_epochs = 3
 
-    @patch('slackker.callbacks.keras.checkker.check_internet')
-    @patch('slackker.callbacks.keras.checkker.get_telegram_chat_id')
-    @patch('slackker.callbacks.keras.checkker.check_internet_epoch_end')
-    @patch('slackker.callbacks.keras.functions.Telegram.report_stats')
-    def test_telegram_on_epoch_end_incomplete_logs_raises(
-        self, mock_report, mock_check_epoch, mock_get_chat_id, mock_check_internet
-    ):
-        mock_check_internet.return_value = True
-        mock_get_chat_id.return_value = "123456789"
-        mock_check_epoch.return_value = True
+        cb.on_train_end()
 
-        callback = TelegramUpdate(token="test_token", ModelName="Test_Model")
+        assert any("Best Accuracy =" in m and "%" in m for m in client.messages)
 
-        with pytest.raises(IndexError):
-            callback.on_epoch_end(batch=0, logs={'accuracy': 0.8, 'loss': 0.2})
 
-    @patch('slackker.callbacks.keras.checkker.check_internet')
-    @patch('slackker.callbacks.keras.checkker.get_telegram_chat_id')
-    @patch('slackker.callbacks.keras.functions.Telegram.report_stats')
-    @patch('slackker.callbacks.keras.functions.Telegram.keras_plot_history')
-    def test_telegram_train_end_message_contains_accuracy_percent(
-        self, mock_plot, mock_report, mock_get_chat_id, mock_check_internet
-    ):
-        mock_check_internet.return_value = True
-        mock_get_chat_id.return_value = "123456789"
+# ── Auto-connect tests ───────────────────────────────────────
 
-        callback = TelegramUpdate(token="test_token", ModelName="Keras_NN", SendPlot=True)
-        callback.train_loss = [0.60, 0.45, 0.35]
-        callback.train_acc = [0.70, 0.80, 0.85]
-        callback.valid_loss = [0.65, 0.50, 0.40]
-        callback.valid_acc = [0.65, 0.75, 0.82]
-        callback.n_epochs = 3
+class DisconnectedMockClient(MockClient):
+    """MockClient that starts disconnected and records connect() calls."""
 
-        callback.on_train_end(logs={})
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.connect_calls = 0
+        self._connected = False
 
-        messages = [c[1]['text'] for c in mock_report.call_args_list]
-        assert any("Best Accuracy =" in m and "%" in m for m in messages)
-        mock_plot.assert_called_once()
+    @property
+    def is_connected(self):
+        return self._connected
+
+    async def connect(self):
+        self.connect_calls += 1
+        self._connected = True
+        return True
+
+
+class TestAutoConnect:
+    """Verify that KerasCallback calls connect() when the client is not yet connected."""
+
+    def test_connects_when_not_connected(self):
+        client = DisconnectedMockClient()
+        assert not client.is_connected
+        KerasCallback(client=client, model_name="M", export="png")
+        assert client.connect_calls == 1
+        assert client.is_connected
+
+    def test_skips_connect_when_already_connected(self):
+        client = MockClient()          # is_connected always True
+        KerasCallback(client=client, model_name="M", export="png")
+        assert client.is_connected
 
 
 if __name__ == "__main__":

--- a/tests/test_lightning.py
+++ b/tests/test_lightning.py
@@ -1,795 +1,351 @@
-"""Tests for slackker.callbacks.lightning module."""
-
-import argparse
-from types import SimpleNamespace
-from unittest.mock import patch
+"""
+Tests for slackker.callbacks.lightning module.
+Tests cover the new unified LightningCallback class and backward-compatible shims.
+"""
 
 import pytest
+import warnings
+import numpy as np
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+from slackker.callbacks.lightning import LightningCallback, SlackUpdate, TelegramUpdate
+from slackker.core.client import BaseClient
 
-from slackker.callbacks.lightning import SlackUpdate, TelegramUpdate
+
+# ── Fixtures ──────────────────────────────────────────────────
+
+class MockClient(BaseClient):
+    """Concrete test client that records calls."""
+
+    def __init__(self, verbose=0, platform_name="mock"):
+        super().__init__(verbose=verbose)
+        self._platform_name = platform_name
+        self.messages = []
+        self.uploaded_files = []
+        self.uploaded_images = []
+
+    @property
+    def platform(self):
+        return self._platform_name
+
+    @property
+    def is_connected(self):
+        return True
+
+    async def send_message(self, text):
+        self.messages.append(text)
+
+    async def upload_file(self, filepath, comment=None):
+        self.uploaded_files.append((filepath, comment))
+
+    async def upload_image(self, filepath, comment=None):
+        self.uploaded_images.append((filepath, comment))
 
 
 def _trainer_with_metrics(metrics):
     return SimpleNamespace(callback_metrics=metrics)
 
 
-class TestSlackUpdateLightningInitialization:
-    @patch("slackker.callbacks.lightning.checkker.check_internet")
-    @patch("slackker.callbacks.lightning.checkker.slack_connect")
-    @patch("slackker.callbacks.lightning.WebClient")
-    def test_init_success(self, mock_web_client, mock_slack_connect, mock_check_internet):
-        mock_check_internet.return_value = True
-        mock_slack_connect.return_value = True
+def _make_callback(
+    platform="slack",
+    verbose=0,
+    track_logs=None,
+    monitor="val_loss",
+    send_plot=False,
+):
+    if track_logs is None:
+        track_logs = ["train_loss", "train_acc", "val_loss", "val_acc"]
+    client = MockClient(verbose=verbose, platform_name=platform)
+    cb = LightningCallback(
+        client=client,
+        model_name="TestModel",
+        track_logs=track_logs,
+        monitor=monitor,
+        export="png",
+        send_plot=send_plot,
+    )
+    return cb, client
 
-        callback = SlackUpdate(
-            token="xoxb-test",
-            channel="C123",
-            ModelName="Lightning NN Testing",
-            TrackLogs=["train_loss", "train_acc", "val_loss", "val_acc"],
-            monitor="val_loss",
-            export="png",
-            SendPlot=True,
-            verbose=2,
-        )
 
-        assert callback.ModelName == "Lightning NN Testing"
-        assert callback.TrackLogs == ["train_loss", "train_acc", "val_loss", "val_acc"]
-        assert callback.monitor == "val_loss"
-        assert callback.export == "png"
-        assert callback.SendPlot is True
-        assert callback.verbose == 2
-        assert callback.training_logs == {}
-        assert callback.n_epochs == 0
-        mock_web_client.assert_called_once_with(token="xoxb-test")
+# ── LightningCallback initialization ─────────────────────────
 
-    @patch("slackker.callbacks.lightning.colors.prRed")
-    def test_init_with_none_token(self, mock_pr_red):
-        SlackUpdate(
-            token=None,
-            channel="C123",
-            ModelName="Model",
-            TrackLogs=["train_loss"],
-            monitor="train_loss",
-        )
-        mock_pr_red.assert_called_once()
+class TestLightningCallbackInit:
+    def test_init_stores_attributes(self):
+        cb, _ = _make_callback()
+        assert cb.model_name == "TestModel"
+        assert cb.track_logs == ["train_loss", "train_acc", "val_loss", "val_acc"]
+        assert cb.monitor == "val_loss"
+        assert cb.export == "png"
+        assert cb.send_plot is False
+        assert cb.training_logs == {}
+        assert cb.n_epochs == 0
 
-    @patch("slackker.callbacks.lightning.checkker.check_internet")
-    @patch("slackker.callbacks.lightning.checkker.slack_connect")
-    @patch("slackker.callbacks.lightning.colors.prRed")
-    @patch("slackker.callbacks.lightning.sys.exit")
-    def test_init_requires_tracklogs(
-        self,
-        mock_exit,
-        mock_pr_red,
-        mock_slack_connect,
-        mock_check_internet,
-    ):
-        mock_check_internet.return_value = True
-        mock_slack_connect.return_value = True
-
-        mock_exit.side_effect = SystemExit
+    def test_init_requires_track_logs(self):
+        m = MockClient()
         with pytest.raises(SystemExit):
-            SlackUpdate(
-                token="xoxb-test",
-                channel="C123",
-                ModelName="Model",
-                TrackLogs=None,
-                monitor="val_loss",
-            )
+            LightningCallback(client=m, model_name="M", track_logs=None, monitor="val_loss")
 
-        mock_pr_red.assert_called()
-        mock_exit.assert_called_once()
-
-    @patch("slackker.callbacks.lightning.checkker.check_internet")
-    @patch("slackker.callbacks.lightning.checkker.slack_connect")
-    @patch("slackker.callbacks.lightning.WebClient")
-    def test_init_export_none_raises(self, mock_web_client, mock_slack_connect, mock_check_internet):
-        mock_check_internet.return_value = True
-        mock_slack_connect.return_value = True
-
-        with pytest.raises(argparse.ArgumentTypeError):
-            SlackUpdate(
-                token="xoxb-test",
-                channel="C123",
-                ModelName="Model",
-                TrackLogs=["train_loss"],
-                monitor="train_loss",
-                export=None,
-            )
-
-    @patch("slackker.callbacks.lightning.checkker.check_internet")
-    @patch("slackker.callbacks.lightning.checkker.slack_connect")
-    @patch("slackker.callbacks.lightning.colors.prYellow")
-    @patch("slackker.callbacks.lightning.WebClient")
-    def test_init_monitor_none_warns(self, mock_web_client, mock_pr_yellow, mock_slack_connect, mock_check_internet):
-        mock_check_internet.return_value = True
-        mock_slack_connect.return_value = True
-
-        SlackUpdate(
-            token="xoxb-test",
-            channel="C123",
-            ModelName="Model",
-            TrackLogs=["train_loss", "val_loss"],
-            monitor=None,
-        )
-
-        mock_pr_yellow.assert_called_once()
-
-    @patch("slackker.callbacks.lightning.checkker.check_internet")
-    @patch("slackker.callbacks.lightning.checkker.slack_connect")
-    @patch("slackker.callbacks.lightning.colors.prRed")
-    @patch("slackker.callbacks.lightning.sys.exit")
-    def test_init_tracklogs_must_be_list(
-        self,
-        mock_exit,
-        mock_pr_red,
-        mock_slack_connect,
-        mock_check_internet,
-    ):
-        mock_check_internet.return_value = True
-        mock_slack_connect.return_value = True
-
-        mock_exit.side_effect = SystemExit
+    def test_init_track_logs_must_be_list(self):
+        m = MockClient()
         with pytest.raises(SystemExit):
-            SlackUpdate(
-                token="xoxb-test",
-                channel="C123",
-                ModelName="Model",
-                TrackLogs="train_loss",
-                monitor="train_loss",
-            )
+            LightningCallback(client=m, model_name="M", track_logs="train_loss", monitor="train_loss")
 
-        mock_pr_red.assert_called()
-        mock_exit.assert_called_once()
-
-    @patch("slackker.callbacks.lightning.checkker.check_internet")
-    @patch("slackker.callbacks.lightning.checkker.slack_connect")
-    @patch("slackker.callbacks.lightning.colors.prRed")
-    @patch("slackker.callbacks.lightning.sys.exit")
-    def test_init_monitor_must_be_in_tracklogs(
-        self,
-        mock_exit,
-        mock_pr_red,
-        mock_slack_connect,
-        mock_check_internet,
-    ):
-        mock_check_internet.return_value = True
-        mock_slack_connect.return_value = True
-
-        mock_exit.side_effect = SystemExit
+    def test_init_monitor_must_be_in_track_logs(self):
+        m = MockClient()
         with pytest.raises(SystemExit):
-            SlackUpdate(
-                token="xoxb-test",
-                channel="C123",
-                ModelName="Model",
-                TrackLogs=["train_loss", "val_loss"],
+            LightningCallback(
+                client=m, model_name="M",
+                track_logs=["train_loss", "val_loss"],
                 monitor="val_acc",
             )
 
-        mock_pr_red.assert_called()
-        mock_exit.assert_called_once()
+    def test_init_monitor_none_warns(self, capsys):
+        # monitor=None should warn but not crash
+        cb, _ = _make_callback(monitor=None)
+        assert cb.monitor is None
+
+    def test_init_rejects_bad_format(self):
+        m = MockClient()
+        with pytest.raises(ValueError, match="Unsupported export format"):
+            LightningCallback(
+                client=m, model_name="M",
+                track_logs=["train_loss"], monitor="train_loss", export="bmp",
+            )
 
 
-class TestSlackUpdateLightningCallbacks:
-    @patch("slackker.callbacks.lightning.checkker.check_internet")
-    @patch("slackker.callbacks.lightning.checkker.slack_connect")
-    @patch("slackker.callbacks.lightning.WebClient")
-    @patch("slackker.callbacks.lightning.functions.Slack.report_stats")
-    def test_on_fit_start_posts_training_start(
-        self,
-        mock_report,
-        mock_web_client,
-        mock_slack_connect,
-        mock_check_internet,
-    ):
-        mock_check_internet.return_value = True
-        mock_slack_connect.return_value = True
+# ── on_fit_start ──────────────────────────────────────────────
 
-        callback = SlackUpdate(
-            token="xoxb-test",
-            channel="C123",
-            ModelName="Lightning NN Testing",
-            TrackLogs=["train_loss", "train_acc", "val_loss", "val_acc"],
-            monitor="val_loss",
-        )
+class TestOnFitStart:
+    def test_posts_training_start(self):
+        cb, client = _make_callback()
+        cb.on_fit_start(trainer=None, pl_module=None)
+        assert len(client.messages) == 1
+        assert "TestModel" in client.messages[0]
+        assert "started at" in client.messages[0]
 
-        callback.on_fit_start(trainer=None, pl_module=None)
 
-        mock_report.assert_called_once()
-        assert "Lightning NN Testing" in mock_report.call_args.kwargs["text"]
+# ── on_train_epoch_end ────────────────────────────────────────
 
-    @patch("slackker.callbacks.lightning.checkker.check_internet")
-    @patch("slackker.callbacks.lightning.checkker.slack_connect")
-    @patch("slackker.callbacks.lightning.WebClient")
-    @patch("slackker.callbacks.lightning.checkker.check_internet_epoch_end")
-    @patch("slackker.callbacks.lightning.functions.Slack.report_stats")
-    def test_on_train_epoch_end_tracks_metrics_and_reports(
-        self,
-        mock_report,
-        mock_epoch_internet,
-        mock_web_client,
-        mock_slack_connect,
-        mock_check_internet,
-    ):
-        mock_check_internet.return_value = True
-        mock_slack_connect.return_value = True
-        mock_epoch_internet.return_value = True
+class TestOnTrainEpochEnd:
+    @patch("slackker.callbacks.lightning.network.check_connection_quick", new_callable=AsyncMock, return_value=True)
+    def test_tracks_metrics_and_reports(self, mock_check):
+        cb, client = _make_callback()
+        trainer = _trainer_with_metrics({
+            "train_loss": 0.90, "train_acc": 0.62, "val_loss": 0.84, "val_acc": 0.67,
+        })
+        cb.on_train_epoch_end(trainer=trainer, pl_module=None)
 
-        callback = SlackUpdate(
-            token="xoxb-test",
-            channel="C123",
-            ModelName="Lightning NN Testing",
-            TrackLogs=["train_loss", "train_acc", "val_loss", "val_acc"],
-            monitor="val_loss",
-        )
+        assert cb.n_epochs == 1
+        assert cb.training_logs["train_loss"] == [0.90]
+        assert cb.training_logs["val_loss"] == [0.84]
+        assert len(client.messages) == 1
+        assert "Epoch: 0" in client.messages[0]
 
-        trainer = _trainer_with_metrics(
-            {
-                "train_loss": 0.90,
-                "train_acc": 0.62,
-                "val_loss": 0.84,
-                "val_acc": 0.67,
-            }
-        )
+    @patch("slackker.callbacks.lightning.network.check_connection_quick", new_callable=AsyncMock, return_value=False)
+    def test_skips_report_without_internet(self, mock_check):
+        cb, client = _make_callback()
+        trainer = _trainer_with_metrics({
+            "train_loss": 0.90, "train_acc": 0.62, "val_loss": 0.84, "val_acc": 0.67,
+        })
+        cb.on_train_epoch_end(trainer=trainer, pl_module=None)
 
-        callback.on_train_epoch_end(trainer=trainer, pl_module=None)
+        assert cb.n_epochs == 1
+        assert cb.training_logs["val_loss"] == [0.84]
+        assert len(client.messages) == 0
 
-        assert callback.n_epochs == 1
-        assert callback.training_logs["train_loss"] == [0.90]
-        assert callback.training_logs["train_acc"] == [0.62]
-        assert callback.training_logs["val_loss"] == [0.84]
-        assert callback.training_logs["val_acc"] == [0.67]
-        mock_report.assert_called_once()
-        assert "Epoch: 0" in mock_report.call_args.kwargs["text"]
 
-    @patch("slackker.callbacks.lightning.checkker.check_internet")
-    @patch("slackker.callbacks.lightning.checkker.slack_connect")
-    @patch("slackker.callbacks.lightning.WebClient")
-    @patch("slackker.callbacks.lightning.checkker.check_internet_epoch_end")
-    @patch("slackker.callbacks.lightning.functions.Slack.report_stats")
-    def test_on_train_epoch_end_skips_report_without_internet(
-        self,
-        mock_report,
-        mock_epoch_internet,
-        mock_web_client,
-        mock_slack_connect,
-        mock_check_internet,
-    ):
-        mock_check_internet.return_value = True
-        mock_slack_connect.return_value = True
-        mock_epoch_internet.return_value = False
+# ── on_fit_end ────────────────────────────────────────────────
 
-        callback = SlackUpdate(
-            token="xoxb-test",
-            channel="C123",
-            ModelName="Lightning NN Testing",
-            TrackLogs=["train_loss", "train_acc", "val_loss", "val_acc"],
-            monitor="val_loss",
-        )
-
-        trainer = _trainer_with_metrics(
-            {
-                "train_loss": 0.90,
-                "train_acc": 0.62,
-                "val_loss": 0.84,
-                "val_acc": 0.67,
-            }
-        )
-
-        callback.on_train_epoch_end(trainer=trainer, pl_module=None)
-
-        assert callback.n_epochs == 1
-        assert callback.training_logs["val_loss"] == [0.84]
-        mock_report.assert_not_called()
-
-    @patch("slackker.callbacks.lightning.checkker.check_internet")
-    @patch("slackker.callbacks.lightning.checkker.slack_connect")
-    @patch("slackker.callbacks.lightning.WebClient")
-    @patch("slackker.callbacks.lightning.functions.Slack.report_stats")
-    @patch("slackker.callbacks.lightning.functions.Slack.lightning_plot_history")
-    def test_on_fit_end_reports_best_epoch_with_loss_monitor(
-        self,
-        mock_plot_history,
-        mock_report,
-        mock_web_client,
-        mock_slack_connect,
-        mock_check_internet,
-    ):
-        mock_check_internet.return_value = True
-        mock_slack_connect.return_value = True
-
-        callback = SlackUpdate(
-            token="xoxb-test",
-            channel="C123",
-            ModelName="Lightning NN Testing",
-            TrackLogs=["train_loss", "train_acc", "val_loss", "val_acc"],
-            monitor="val_loss",
-            SendPlot=True,
-        )
-        callback.training_logs = {
+class TestOnFitEnd:
+    def test_reports_best_epoch_loss_monitor(self):
+        cb, client = _make_callback(monitor="val_loss")
+        cb.training_logs = {
             "train_loss": [0.9, 0.7, 0.5],
             "train_acc": [0.6, 0.7, 0.8],
             "val_loss": [0.8, 0.4, 0.6],
             "val_acc": [0.65, 0.75, 0.72],
         }
-        callback.n_epochs = 3
+        cb.n_epochs = 3
 
-        callback.on_fit_end(trainer=None, pl_module=None)
+        cb.on_fit_end(trainer=None, pl_module=None)
 
-        mock_report.assert_called_once()
-        assert "Best epoch was, Epoch 1" in mock_report.call_args.kwargs["text"]
-        mock_plot_history.assert_called_once()
+        found = any("Best epoch was, Epoch 1" in m for m in client.messages)
+        assert found
 
-    @patch("slackker.callbacks.lightning.checkker.check_internet")
-    @patch("slackker.callbacks.lightning.checkker.slack_connect")
-    @patch("slackker.callbacks.lightning.WebClient")
-    @patch("slackker.callbacks.lightning.functions.Slack.report_stats")
-    @patch("slackker.callbacks.lightning.functions.Slack.lightning_plot_history")
-    def test_on_fit_end_without_monitor_uses_fallback_message(
-        self,
-        mock_plot_history,
-        mock_report,
-        mock_web_client,
-        mock_slack_connect,
-        mock_check_internet,
-    ):
-        mock_check_internet.return_value = True
-        mock_slack_connect.return_value = True
-
-        callback = SlackUpdate(
-            token="xoxb-test",
-            channel="C123",
-            ModelName="Lightning NN Testing",
-            TrackLogs=["train_loss", "train_acc", "val_loss", "val_acc"],
-            monitor=None,
-        )
-        callback.training_logs = {
-            "train_loss": [0.9],
-            "train_acc": [0.6],
-            "val_loss": [0.8],
-            "val_acc": [0.65],
-        }
-        callback.n_epochs = 1
-
-        callback.on_fit_end(trainer=None, pl_module=None)
-
-        mock_report.assert_called_once()
-        assert "monitor' was not provided" in mock_report.call_args.kwargs["text"]
-        mock_plot_history.assert_called_once()
-        assert mock_plot_history.call_args.kwargs["training_logs"] == callback.training_logs
-
-    @patch("slackker.callbacks.lightning.checkker.check_internet")
-    @patch("slackker.callbacks.lightning.checkker.slack_connect")
-    @patch("slackker.callbacks.lightning.WebClient")
-    @patch("slackker.callbacks.lightning.functions.Slack.report_stats")
-    @patch("slackker.callbacks.lightning.functions.Slack.lightning_plot_history")
-    def test_on_fit_end_reports_best_epoch_with_acc_monitor(
-        self,
-        mock_plot_history,
-        mock_report,
-        mock_web_client,
-        mock_slack_connect,
-        mock_check_internet,
-    ):
-        mock_check_internet.return_value = True
-        mock_slack_connect.return_value = True
-
-        callback = SlackUpdate(
-            token="xoxb-test",
-            channel="C123",
-            ModelName="Lightning NN Testing",
-            TrackLogs=["train_loss", "train_acc", "val_loss", "val_acc"],
-            monitor="val_acc",
-        )
-        callback.training_logs = {
+    def test_reports_best_epoch_acc_monitor(self):
+        cb, client = _make_callback(monitor="val_acc")
+        cb.training_logs = {
             "val_acc": [0.50, 0.72, 0.69],
             "val_loss": [0.7, 0.5, 0.6],
         }
-        callback.n_epochs = 3
+        cb.n_epochs = 3
 
-        callback.on_fit_end(trainer=None, pl_module=None)
+        cb.on_fit_end(trainer=None, pl_module=None)
 
-        mock_report.assert_called_once()
-        assert "Best epoch was, Epoch 1" in mock_report.call_args.kwargs["text"]
-        mock_plot_history.assert_called_once()
+        found = any("Best epoch was, Epoch 1" in m for m in client.messages)
+        assert found
 
+    def test_no_monitor_fallback_message(self):
+        cb, client = _make_callback(monitor=None)
+        cb.training_logs = {"train_loss": [0.9], "val_loss": [0.8]}
+        cb.n_epochs = 1
 
-class TestTelegramUpdateLightningInitialization:
-    @patch("slackker.callbacks.lightning.checkker.check_internet")
-    @patch("slackker.callbacks.lightning.checkker.get_telegram_chat_id")
-    def test_init_success(self, mock_get_chat_id, mock_check_internet):
-        mock_check_internet.return_value = True
-        mock_get_chat_id.return_value = "987654321"
+        cb.on_fit_end(trainer=None, pl_module=None)
 
-        callback = TelegramUpdate(
-            token="telegram-token",
-            ModelName="Lightning NN Testing",
-            TrackLogs=["train_loss", "train_acc", "val_loss", "val_acc"],
-            monitor="val_loss",
-            export="png",
-            SendPlot=True,
-            verbose=2,
-        )
+        found = any("monitor' was not provided" in m for m in client.messages)
+        assert found
 
-        assert callback.token == "telegram-token"
-        assert callback.channel == "987654321"
-        assert callback.TrackLogs == ["train_loss", "train_acc", "val_loss", "val_acc"]
-        assert callback.monitor == "val_loss"
-        assert callback.training_logs == {}
-        assert callback.n_epochs == 0
+    @patch("slackker.callbacks.lightning.plotting.generate_and_get_plots", return_value=["/tmp/loss.png", "/tmp/acc.png"])
+    def test_uploads_plots_when_enabled(self, mock_plots):
+        cb, client = _make_callback(send_plot=True)
+        cb.training_logs = {"train_loss": [0.9, 0.7], "val_loss": [0.8, 0.6]}
+        cb.n_epochs = 2
 
-    @patch("slackker.callbacks.lightning.colors.prRed")
-    def test_init_with_none_token(self, mock_pr_red):
-        TelegramUpdate(
-            token=None,
-            ModelName="Model",
-            TrackLogs=["train_loss"],
-            monitor="train_loss",
-        )
-        mock_pr_red.assert_called_once()
+        cb.on_fit_end(trainer=None, pl_module=None)
 
-    @patch("slackker.callbacks.lightning.checkker.check_internet")
-    @patch("slackker.callbacks.lightning.checkker.get_telegram_chat_id")
-    @patch("slackker.callbacks.lightning.sys.exit")
-    @patch("slackker.callbacks.lightning.colors.prRed")
-    def test_init_requires_tracklogs(
-        self,
-        mock_pr_red,
-        mock_exit,
-        mock_get_chat_id,
-        mock_check_internet,
-    ):
-        mock_check_internet.return_value = True
-        mock_get_chat_id.return_value = "987654321"
-
-        mock_exit.side_effect = SystemExit
-        with pytest.raises(SystemExit):
-            TelegramUpdate(
-                token="telegram-token",
-                ModelName="Model",
-                TrackLogs=None,
-                monitor="val_loss",
-            )
-
-        mock_pr_red.assert_called()
-        mock_exit.assert_called_once()
-
-    @patch("slackker.callbacks.lightning.checkker.check_internet")
-    @patch("slackker.callbacks.lightning.checkker.get_telegram_chat_id")
-    @patch("slackker.callbacks.lightning.sys.exit")
-    @patch("slackker.callbacks.lightning.colors.prRed")
-    def test_init_tracklogs_must_be_list(
-        self,
-        mock_pr_red,
-        mock_exit,
-        mock_get_chat_id,
-        mock_check_internet,
-    ):
-        mock_check_internet.return_value = True
-        mock_get_chat_id.return_value = "987654321"
-
-        mock_exit.side_effect = SystemExit
-        with pytest.raises(SystemExit):
-            TelegramUpdate(
-                token="telegram-token",
-                ModelName="Model",
-                TrackLogs="train_loss",
-                monitor="train_loss",
-            )
-
-        mock_pr_red.assert_called()
-        mock_exit.assert_called_once()
-
-    @patch("slackker.callbacks.lightning.checkker.check_internet")
-    @patch("slackker.callbacks.lightning.checkker.get_telegram_chat_id")
-    @patch("slackker.callbacks.lightning.colors.prRed")
-    @patch("slackker.callbacks.lightning.sys.exit")
-    def test_init_monitor_must_be_in_tracklogs(
-        self,
-        mock_exit,
-        mock_pr_red,
-        mock_get_chat_id,
-        mock_check_internet,
-    ):
-        mock_check_internet.return_value = True
-        mock_get_chat_id.return_value = "987654321"
-
-        mock_exit.side_effect = SystemExit
-        with pytest.raises(SystemExit):
-            TelegramUpdate(
-                token="telegram-token",
-                ModelName="Model",
-                TrackLogs=["train_loss", "val_loss"],
-                monitor="val_acc",
-            )
-
-        mock_pr_red.assert_called()
-        mock_exit.assert_called_once()
-
-    @patch("slackker.callbacks.lightning.checkker.check_internet")
-    @patch("slackker.callbacks.lightning.checkker.get_telegram_chat_id")
-    @patch("slackker.callbacks.lightning.colors.prYellow")
-    def test_init_monitor_none_warns(self, mock_pr_yellow, mock_get_chat_id, mock_check_internet):
-        mock_check_internet.return_value = True
-        mock_get_chat_id.return_value = "987654321"
-
-        TelegramUpdate(
-            token="telegram-token",
-            ModelName="Model",
-            TrackLogs=["train_loss", "val_loss"],
-            monitor=None,
-        )
-
-        mock_pr_yellow.assert_called_once()
-
-    @patch("slackker.callbacks.lightning.checkker.check_internet")
-    @patch("slackker.callbacks.lightning.checkker.get_telegram_chat_id")
-    def test_init_export_none_raises(self, mock_get_chat_id, mock_check_internet):
-        mock_check_internet.return_value = True
-        mock_get_chat_id.return_value = "987654321"
-
-        with pytest.raises(argparse.ArgumentTypeError):
-            TelegramUpdate(
-                token="telegram-token",
-                ModelName="Model",
-                TrackLogs=["train_loss"],
-                monitor="train_loss",
-                export=None,
-            )
+        assert len(client.uploaded_images) == 2
+        mock_plots.assert_called_once()
 
 
-class TestTelegramUpdateLightningCallbacks:
-    @patch("slackker.callbacks.lightning.checkker.check_internet")
-    @patch("slackker.callbacks.lightning.checkker.get_telegram_chat_id")
-    @patch("slackker.callbacks.lightning.functions.Telegram.report_stats")
-    def test_on_fit_start_posts_training_start(
-        self,
-        mock_report,
-        mock_get_chat_id,
-        mock_check_internet,
-    ):
-        mock_check_internet.return_value = True
-        mock_get_chat_id.return_value = "987654321"
+# ── Complete workflow ─────────────────────────────────────────
 
-        callback = TelegramUpdate(
-            token="telegram-token",
-            ModelName="Lightning NN Testing",
-            TrackLogs=["train_loss", "train_acc", "val_loss", "val_acc"],
-            monitor="val_loss",
-        )
+class TestCompleteWorkflow:
+    @patch("slackker.callbacks.lightning.network.check_connection_quick", new_callable=AsyncMock, return_value=True)
+    @patch("slackker.callbacks.lightning.plotting.generate_and_get_plots", return_value=["/tmp/loss.png"])
+    def test_full_training(self, mock_plots, mock_check):
+        cb, client = _make_callback(send_plot=True)
 
-        callback.on_fit_start(trainer=None, pl_module=None)
-
-        mock_report.assert_called_once()
-        assert "Lightning NN Testing" in mock_report.call_args.kwargs["text"]
-
-    @patch("slackker.callbacks.lightning.checkker.check_internet")
-    @patch("slackker.callbacks.lightning.checkker.get_telegram_chat_id")
-    @patch("slackker.callbacks.lightning.checkker.check_internet_epoch_end")
-    @patch("slackker.callbacks.lightning.functions.Telegram.report_stats")
-    def test_on_train_epoch_end_tracks_metrics_and_reports(
-        self,
-        mock_report,
-        mock_epoch_internet,
-        mock_get_chat_id,
-        mock_check_internet,
-    ):
-        mock_check_internet.return_value = True
-        mock_get_chat_id.return_value = "987654321"
-        mock_epoch_internet.return_value = True
-
-        callback = TelegramUpdate(
-            token="telegram-token",
-            ModelName="Lightning NN Testing",
-            TrackLogs=["train_loss", "train_acc", "val_loss", "val_acc"],
-            monitor="val_loss",
-        )
-
-        trainer = _trainer_with_metrics(
-            {
-                "train_loss": 0.90,
-                "train_acc": 0.62,
-                "val_loss": 0.84,
-                "val_acc": 0.67,
-            }
-        )
-
-        callback.on_train_epoch_end(trainer=trainer, pl_module=None)
-
-        assert callback.n_epochs == 1
-        assert callback.training_logs["val_loss"] == [0.84]
-        mock_report.assert_called_once()
-        assert "Epoch: 0" in mock_report.call_args.kwargs["text"]
-
-    @patch("slackker.callbacks.lightning.checkker.check_internet")
-    @patch("slackker.callbacks.lightning.checkker.get_telegram_chat_id")
-    @patch("slackker.callbacks.lightning.checkker.check_internet_epoch_end")
-    @patch("slackker.callbacks.lightning.functions.Telegram.report_stats")
-    def test_on_train_epoch_end_no_internet_skips_report(
-        self,
-        mock_report,
-        mock_epoch_internet,
-        mock_get_chat_id,
-        mock_check_internet,
-    ):
-        mock_check_internet.return_value = True
-        mock_get_chat_id.return_value = "987654321"
-        mock_epoch_internet.return_value = False
-
-        callback = TelegramUpdate(
-            token="telegram-token",
-            ModelName="Lightning NN Testing",
-            TrackLogs=["train_loss", "train_acc", "val_loss", "val_acc"],
-            monitor="val_loss",
-        )
-
-        trainer = _trainer_with_metrics(
-            {
-                "train_loss": 0.90,
-                "train_acc": 0.62,
-                "val_loss": 0.84,
-                "val_acc": 0.67,
-            }
-        )
-
-        callback.on_train_epoch_end(trainer=trainer, pl_module=None)
-
-        assert callback.n_epochs == 1
-        assert callback.training_logs["val_loss"] == [0.84]
-        mock_report.assert_not_called()
-        mock_epoch_internet.assert_called_once_with(url="www.slack.com")
-
-    @patch("slackker.callbacks.lightning.checkker.check_internet")
-    @patch("slackker.callbacks.lightning.checkker.get_telegram_chat_id")
-    @patch("slackker.callbacks.lightning.functions.Telegram.report_stats")
-    @patch("slackker.callbacks.lightning.functions.Telegram.lightning_plot_history")
-    def test_on_fit_end_reports_best_epoch_with_loss_monitor(
-        self,
-        mock_plot_history,
-        mock_report,
-        mock_get_chat_id,
-        mock_check_internet,
-    ):
-        mock_check_internet.return_value = True
-        mock_get_chat_id.return_value = "987654321"
-
-        callback = TelegramUpdate(
-            token="telegram-token",
-            ModelName="Lightning NN Testing",
-            TrackLogs=["train_loss", "train_acc", "val_loss", "val_acc"],
-            monitor="val_loss",
-            SendPlot=True,
-        )
-        callback.training_logs = {
-            "train_loss": [0.9, 0.7, 0.5],
-            "train_acc": [0.6, 0.7, 0.8],
-            "val_loss": [0.8, 0.4, 0.6],
-            "val_acc": [0.65, 0.75, 0.72],
-        }
-        callback.n_epochs = 3
-
-        callback.on_fit_end(trainer=None, pl_module=None)
-
-        mock_report.assert_called_once()
-        assert "Best epoch was, Epoch 1" in mock_report.call_args.kwargs["text"]
-        mock_plot_history.assert_called_once()
-
-    @patch("slackker.callbacks.lightning.checkker.check_internet")
-    @patch("slackker.callbacks.lightning.checkker.get_telegram_chat_id")
-    @patch("slackker.callbacks.lightning.functions.Telegram.report_stats")
-    @patch("slackker.callbacks.lightning.functions.Telegram.lightning_plot_history")
-    def test_on_fit_end_reports_best_epoch_with_acc_monitor(
-        self,
-        mock_plot_history,
-        mock_report,
-        mock_get_chat_id,
-        mock_check_internet,
-    ):
-        mock_check_internet.return_value = True
-        mock_get_chat_id.return_value = "987654321"
-
-        callback = TelegramUpdate(
-            token="telegram-token",
-            ModelName="Lightning NN Testing",
-            TrackLogs=["train_loss", "train_acc", "val_loss", "val_acc"],
-            monitor="val_acc",
-        )
-        callback.training_logs = {
-            "val_acc": [0.50, 0.72, 0.69],
-            "val_loss": [0.7, 0.5, 0.6],
-        }
-        callback.n_epochs = 3
-
-        callback.on_fit_end(trainer=None, pl_module=None)
-
-        mock_report.assert_called_once()
-        assert "Best epoch was, Epoch 1" in mock_report.call_args.kwargs["text"]
-        mock_plot_history.assert_called_once()
-
-    @patch("slackker.callbacks.lightning.checkker.check_internet")
-    @patch("slackker.callbacks.lightning.checkker.get_telegram_chat_id")
-    @patch("slackker.callbacks.lightning.functions.Telegram.report_stats")
-    @patch("slackker.callbacks.lightning.functions.Telegram.lightning_plot_history")
-    def test_on_fit_end_without_monitor_uses_fallback_message(
-        self,
-        mock_plot_history,
-        mock_report,
-        mock_get_chat_id,
-        mock_check_internet,
-    ):
-        mock_check_internet.return_value = True
-        mock_get_chat_id.return_value = "987654321"
-
-        callback = TelegramUpdate(
-            token="telegram-token",
-            ModelName="Lightning NN Testing",
-            TrackLogs=["train_loss", "train_acc", "val_loss", "val_acc"],
-            monitor=None,
-        )
-        callback.training_logs = {
-            "train_loss": [0.9],
-            "train_acc": [0.6],
-            "val_loss": [0.8],
-            "val_acc": [0.65],
-        }
-        callback.n_epochs = 1
-
-        callback.on_fit_end(trainer=None, pl_module=None)
-
-        mock_report.assert_called_once()
-        assert "monitor' was not provided" in mock_report.call_args.kwargs["text"]
-        mock_plot_history.assert_called_once()
-
-
-class TestLightningWorkflowIntegration:
-    @patch("slackker.callbacks.lightning.checkker.check_internet")
-    @patch("slackker.callbacks.lightning.checkker.get_telegram_chat_id")
-    @patch("slackker.callbacks.lightning.checkker.check_internet_epoch_end")
-    @patch("slackker.callbacks.lightning.functions.Telegram.report_stats")
-    @patch("slackker.callbacks.lightning.functions.Telegram.lightning_plot_history")
-    def test_telegram_reference_workflow_from_sample(
-        self,
-        mock_plot_history,
-        mock_report,
-        mock_epoch_internet,
-        mock_get_chat_id,
-        mock_check_internet,
-    ):
-        """Simulates the sample Trainer workflow in the user example."""
-        mock_check_internet.return_value = True
-        mock_get_chat_id.return_value = "987654321"
-        mock_epoch_internet.return_value = True
-
-        callback = TelegramUpdate(
-            token="6703340847:AAECWu8qLPTIRMDGjXjzwT5UbK_9P13WdK8",
-            ModelName="Lightning NN Testing",
-            TrackLogs=["train_loss", "train_acc", "val_loss", "val_acc"],
-            monitor="val_loss",
-            export="png",
-            SendPlot=True,
-            verbose=2,
-        )
-
-        callback.on_fit_start(trainer=None, pl_module=None)
-
+        cb.on_fit_start(trainer=None, pl_module=None)
         for epoch in range(6):
-            trainer = _trainer_with_metrics(
-                {
-                    "train_loss": 0.90 - (0.05 * epoch),
-                    "train_acc": 0.60 + (0.04 * epoch),
-                    "val_loss": 0.85 - (0.04 * epoch),
-                    "val_acc": 0.62 + (0.03 * epoch),
-                }
+            trainer = _trainer_with_metrics({
+                "train_loss": 0.90 - (0.05 * epoch),
+                "train_acc": 0.60 + (0.04 * epoch),
+                "val_loss": 0.85 - (0.04 * epoch),
+                "val_acc": 0.62 + (0.03 * epoch),
+            })
+            cb.on_train_epoch_end(trainer=trainer, pl_module=None)
+        cb.on_fit_end(trainer=None, pl_module=None)
+
+        assert cb.n_epochs == 6
+        assert len(cb.training_logs["train_loss"]) == 6
+        # 1 begin + 6 epochs + 1 summary
+        assert len(client.messages) == 8
+
+
+# ── Backward-compat shim tests ───────────────────────────────
+
+class TestSlackUpdateShim:
+    @patch("slackker.callbacks.lightning.SlackClient")
+    def test_init_deprecation_warning(self, mock_cls):
+        mock_client = MockClient()
+        mock_client.connect = AsyncMock(return_value=True)
+        mock_client._client = MagicMock()
+        mock_cls.return_value = mock_client
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            cb = SlackUpdate(
+                token="xoxb-test", channel="C123", ModelName="M",
+                TrackLogs=["train_loss"], monitor="train_loss",
             )
-            callback.on_train_epoch_end(trainer=trainer, pl_module=None)
+            assert any(issubclass(x.category, DeprecationWarning) for x in w)
 
-        callback.on_fit_end(trainer=None, pl_module=None)
+    @patch("slackker.callbacks.lightning.SlackClient")
+    def test_shim_preserves_old_attrs(self, mock_cls):
+        mock_client = MockClient()
+        mock_client.connect = AsyncMock(return_value=True)
+        mock_client._client = MagicMock()
+        mock_cls.return_value = mock_client
 
-        assert callback.n_epochs == 6
-        assert len(callback.training_logs["train_loss"]) == 6
-        assert len(callback.training_logs["val_loss"]) == 6
-        assert mock_report.call_count == 8
-        mock_plot_history.assert_called_once()
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            cb = SlackUpdate(
+                token="xoxb-test", channel="C123", ModelName="M",
+                TrackLogs=["train_loss", "val_loss"], monitor="val_loss",
+                SendPlot=True, verbose=2,
+            )
+
+        assert cb.ModelName == "M"
+        assert cb.TrackLogs == ["train_loss", "val_loss"]
+        assert cb.SendPlot is True
+        assert cb.verbose == 2
+
+    def test_no_token(self):
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            cb = SlackUpdate(
+                token=None, channel="C123", ModelName="M",
+                TrackLogs=["train_loss"], monitor="train_loss",
+            )
+        assert not hasattr(cb, "client")
+
+
+class TestTelegramUpdateShim:
+    @patch("slackker.callbacks.lightning.TelegramClient")
+    def test_init_deprecation_warning(self, mock_cls):
+        mock_client = MockClient()
+        mock_client.connect = AsyncMock(return_value=True)
+        mock_client.chat_id = "99999"
+        mock_cls.return_value = mock_client
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            cb = TelegramUpdate(
+                token="123:ABC", ModelName="M",
+                TrackLogs=["train_loss"], monitor="train_loss",
+            )
+            assert any(issubclass(x.category, DeprecationWarning) for x in w)
+
+    def test_no_token(self):
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            cb = TelegramUpdate(
+                token=None, ModelName="M",
+                TrackLogs=["train_loss"], monitor="train_loss",
+            )
+        assert not hasattr(cb, "client")
+
+
+# ── Auto-connect tests ───────────────────────────────────────
+
+class DisconnectedMockClient(MockClient):
+    """MockClient that starts disconnected and records connect() calls."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.connect_calls = 0
+        self._connected = False
+
+    @property
+    def is_connected(self):
+        return self._connected
+
+    async def connect(self):
+        self.connect_calls += 1
+        self._connected = True
+        return True
+
+
+class TestAutoConnect:
+    """Verify that LightningCallback calls connect() when the client is not yet connected."""
+
+    def test_connects_when_not_connected(self):
+        client = DisconnectedMockClient()
+        assert not client.is_connected
+        LightningCallback(
+            client=client, model_name="M",
+            track_logs=["train_loss"], monitor="train_loss",
+        )
+        assert client.connect_calls == 1
+        assert client.is_connected
+
+    def test_skips_connect_when_already_connected(self):
+        client = MockClient()          # is_connected always True
+        LightningCallback(
+            client=client, model_name="M",
+            track_logs=["train_loss"], monitor="train_loss",
+        )
+        assert client.is_connected
 
 
 if __name__ == "__main__":

--- a/uv.lock
+++ b/uv.lock
@@ -141,6 +141,19 @@ wheels = [
 ]
 
 [[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
 name = "astunparse"
 version = "1.6.3"
 source = { registry = "https://pypi.org/simple" }
@@ -793,6 +806,15 @@ wheels = [
 ]
 
 [[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
 name = "h5py"
 version = "3.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -816,6 +838,34 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0d/ce/3a21d87896bc7e3e9255e0ad5583ae31ae9e6b4b00e0bcb2a67e2b6acdbc/h5py-3.14.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e8cbaf6910fa3983c46172666b0b8da7b7bd90d764399ca983236f2400436eeb", size = 4700675, upload-time = "2025-06-06T14:05:37.38Z" },
     { url = "https://files.pythonhosted.org/packages/e7/ec/86f59025306dcc6deee5fda54d980d077075b8d9889aac80f158bd585f1b/h5py-3.14.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d90e6445ab7c146d7f7981b11895d70bc1dd91278a4f9f9028bc0c95e4a53f13", size = 4921632, upload-time = "2025-06-06T14:05:43.464Z" },
     { url = "https://files.pythonhosted.org/packages/3f/6d/0084ed0b78d4fd3e7530c32491f2884140d9b06365dac8a08de726421d4a/h5py-3.14.0-cp313-cp313-win_amd64.whl", hash = "sha256:ae18e3de237a7a830adb76aaa68ad438d85fe6e19e0d99944a3ce46b772c69b3", size = 2852929, upload-time = "2025-06-06T14:05:47.659Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
 [[package]]
@@ -1030,6 +1080,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f1/45/7fa8f56b17dc0f0a41ec70dd307ecd6787254483549843bef4c30ab5adce/lightning_utilities-0.15.3.tar.gz", hash = "sha256:792ae0204c79f6859721ac7f386c237a33b0ed06ba775009cb894e010a842033", size = 33553, upload-time = "2026-02-22T14:48:53.348Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/25/f4/ead6e0e37209b07c9baa3e984ccdb0348ca370b77cea3aaea8ddbb097e00/lightning_utilities-0.15.3-py3-none-any.whl", hash = "sha256:6c55f1bee70084a1cbeaa41ada96e4b3a0fea5909e844dd335bd80f5a73c5f91", size = 31906, upload-time = "2026-02-22T14:48:52.488Z" },
+]
+
+[[package]]
+name = "loguru"
+version = "0.7.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "win32-setctime", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3a/05/a1dae3dffd1116099471c643b8924f5aa6524411dc6c63fdae648c4f1aca/loguru-0.7.3.tar.gz", hash = "sha256:19480589e77d47b8d85b2c827ad95d49bf31b0dcde16593892eb51dd18706eb6", size = 63559, upload-time = "2024-12-06T11:20:56.608Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl", hash = "sha256:31a33c10c8e1e10422bfd431aeb5d351c7cf7fa671e3c4df004162264b28220c", size = 61595, upload-time = "2024-12-06T11:20:54.538Z" },
 ]
 
 [[package]]
@@ -1955,6 +2018,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
 name = "pytest-cov"
 version = "7.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2235,8 +2311,12 @@ name = "slackker"
 version = "1.2.39"
 source = { editable = "." }
 dependencies = [
+    { name = "aiohttp" },
+    { name = "httpx" },
+    { name = "loguru" },
     { name = "matplotlib" },
     { name = "numpy" },
+    { name = "requests" },
     { name = "slack-sdk" },
 ]
 
@@ -2245,6 +2325,7 @@ dev = [
     { name = "keras" },
     { name = "lightning" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "scikit-learn" },
     { name = "tensorflow" },
@@ -2254,8 +2335,12 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aiohttp", specifier = ">=3.9.0" },
+    { name = "httpx", specifier = ">=0.27.0" },
+    { name = "loguru", specifier = ">=0.7.0" },
     { name = "matplotlib", specifier = ">=3.7.5" },
     { name = "numpy", specifier = ">=1.24.4" },
+    { name = "requests", specifier = ">=2.31.0" },
     { name = "slack-sdk", specifier = ">=3.39.0" },
 ]
 
@@ -2264,6 +2349,7 @@ dev = [
     { name = "keras", specifier = ">=3.13.2" },
     { name = "lightning", specifier = ">=2.6.1" },
     { name = "pytest", specifier = ">=7.0.0" },
+    { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "pytest-cov", specifier = ">=4.0.0" },
     { name = "scikit-learn", specifier = ">=1.7.2" },
     { name = "tensorflow", specifier = ">=2.21.0" },
@@ -2584,6 +2670,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/39/62/75f18a0f03b4219c456652c7780e4d749b929eb605c098ce3a5b6b6bc081/wheel-0.47.0.tar.gz", hash = "sha256:cc72bd1009ba0cf63922e28f94d9d83b920aa2bb28f798a31d0691b02fa3c9b3", size = 63854, upload-time = "2026-04-22T15:51:27.727Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/87/1b/9e33c09813d65e248f7f773119148a612516a4bea93e9c6f545f78455b7c/wheel-0.47.0-py3-none-any.whl", hash = "sha256:212281cab4dff978f6cedd499cd893e1f620791ca6ff7107cf270781e587eced", size = 32218, upload-time = "2026-04-22T15:51:26.296Z" },
+]
+
+[[package]]
+name = "win32-setctime"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b3/8f/705086c9d734d3b663af0e9bb3d4de6578d08f46b1b101c2442fd9aecaa2/win32_setctime-1.2.0.tar.gz", hash = "sha256:ae1fdf948f5640aae05c511ade119313fb6a30d7eabe25fef9764dca5873c4c0", size = 4867, upload-time = "2024-12-07T15:28:28.314Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/07/c6fe3ad3e685340704d314d765b7912993bcb8dc198f0e7a89382d37974b/win32_setctime-1.2.0-py3-none-any.whl", hash = "sha256:95d644c4e708aba81dc3704a116d8cbc974d70b3bdb8be1d150e36be6e9d1390", size = 4083, upload-time = "2024-12-07T15:28:26.465Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -2308,7 +2308,7 @@ wheels = [
 
 [[package]]
 name = "slackker"
-version = "1.2.39"
+version = "1.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/website/index.html
+++ b/website/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>slackker | Real-time Pipeline Notifications</title>
+  <title>slackker — Real-time Pipeline Notifications</title>
   <meta name="description" content="Monitor any Python script, data pipeline, or ML training run in real-time via Slack and Telegram with slackker callbacks." />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -22,8 +22,8 @@
     <button id="menuButton" class="menu-btn" aria-expanded="false" aria-controls="navLinks">Menu</button>
     <nav id="navLinks" class="nav-links">
       <a href="#features">Features</a>
-      <a href="#examples">Examples</a>
       <a href="#quickstart">Quick Start</a>
+      <a href="#usage">Usage</a>
       <a href="https://pypi.org/project/slackker/" target="_blank" rel="noreferrer">PyPI</a>
     </nav>
   </header>
@@ -37,12 +37,17 @@
         ML training run, or automation workflow — complete with metrics, outputs, and optional plots.
       </p>
       <div class="hero-cta center-wrap">
-        <a class="btn btn-primary" href="https://pypi.org/project/slackker/" target="_blank" rel="noreferrer">pip install slackker</a>
         <a class="btn btn-ghost" href="https://github.com/siddheshgunjal/slackker" target="_blank" rel="noreferrer">
           <svg width="24" height="24" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
             <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/>
           </svg>
           View on GitHub
+        </a>
+        <a href="#quickstart" class="btn btn-primary">
+            <svg width="24" height="24" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"/>
+            </svg>
+            Quick Start
         </a>
       </div>
       <div class="hero-code glass center-block">
@@ -51,10 +56,17 @@
           <span class="ide-dot dot-yellow"></span>
           <span class="ide-dot dot-green"></span>
           <span class="ide-filename">main.py</span>
+          <div class="platform-toggle" role="group" aria-label="Switch client">
+            <span class="platform-label">Client: </span>
+            <button class="plt-btn active" data-platform="telegram">Telegram</button>
+            <button class="plt-btn" data-platform="slack">Slack</button>
+          </div>
         </div>
-<pre><code>from slackker.callbacks.basic import SlackUpdate
+<pre><code class="code-python" data-snippet="hero">from slackker.core import TelegramClient
+from slackker.callbacks.simple import SimpleCallback
 
-slackker = SlackUpdate(token="xoxb-...", channel="A04AAB77ABC")
+client = TelegramClient(token="123456:ABC-DEF...")
+slackker = SimpleCallback(client)
 
 @slackker.notifier
 def train_model():
@@ -71,25 +83,62 @@ slackker.notify(event="training_complete", status="completed")</code></pre>
       </div>
       <div class="cards">
         <article class="card glass center-text">
+          <div class="card-icon" aria-hidden="true">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
+              <path d="M24 4.5c-5.5 0-9.5 2.5-9.5 7V16h10v2H12c-3.5 0-6 2.8-6 7s2.5 7 6 7h3v-3.5c0-3.5 2.5-6 6.5-6h6c3.5 0 6-2.5 6-6.5V11.5c0-4.5-4-7-9.5-7zM20.5 9.5a1.5 1.5 0 1 0 3 0 1.5 1.5 0 0 0-3 0z" fill="#3776AB"/>
+              <path d="M24 43.5c5.5 0 9.5-2.5 9.5-7V32h-10v-2H36c3.5 0 6-2.8 6-7s-2.5-7-6-7h-3v3.5c0 3.5-2.5 6-6.5 6h-6c-3.5 0-6 2.5-6 6.5v5c0 4.5 4 7 9.5 7zM26.5 38.5a1.5 1.5 0 1 0 3 0 1.5 1.5 0 0 0-3 0z" fill="#FFD43B"/>
+            </svg>
+          </div>
           <h3>Any Python Function</h3>
           <p>Decorator-based notifications for script execution with returned output summaries.</p>
         </article>
         <article class="card glass center-text">
+          <div class="card-icon" aria-hidden="true">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
+              <circle cx="24" cy="24" r="22" fill="#D00000"/>
+              <path d="M16 13h5v9L30 13h6L26 24l10 11h-6L21 25v10h-5z" fill="white"/>
+            </svg>
+          </div>
           <h3>Keras Callback</h3>
           <p>Attach to model.fit and receive metric progress during epoch training.</p>
         </article>
         <article class="card glass center-text">
+          <div class="card-icon" aria-hidden="true">
+            <img src="https://miro.medium.com/v2/1*f1Y6xXw2Uab_-T2Q0C02Zg.png" alt="PyTorch Lightning" />
+          </div>
           <h3>Lightning Callback</h3>
           <p>Track train and validation logs with monitor-based best epoch updates.</p>
         </article>
         <article class="card glass center-text">
+          <div class="card-icon" aria-hidden="true">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
+              <rect x="6" y="28" width="9" height="14" rx="2" fill="var(--teal)"/>
+              <rect x="19.5" y="18" width="9" height="24" rx="2" fill="var(--teal)"/>
+              <rect x="33" y="10" width="9" height="32" rx="2" fill="var(--teal)"/>
+              <rect x="4" y="43" width="40" height="2.5" rx="1.25" fill="var(--teal)"/>
+            </svg>
+          </div>
           <h3>Plot Sharing</h3>
           <p>Export and send history plots so you can check model behavior quickly on mobile.</p>
         </article>
       </div>
     </section>
 
-    <section id="examples" class="section reveal">
+    <section id="quickstart" class="section reveal quickstart-section">
+      <div class="section-head center-text">
+        <p class="eyebrow">Quick start</p>
+        <h2>From install to updates in five steps</h2>
+      </div>
+      <ol class="steps center-block">
+        <li class="glass"><span>1</span>Install package: <code>pip install slackker</code></li>
+        <li class="glass"><span>2</span>Setup Slack app token and channel, or Telegram bot token.</li>
+        <li class="glass"><span>3</span>Create a <code>SlackClient</code> or <code>TelegramClient</code> with your credentials.</li>
+        <li class="glass"><span>4</span>Pass the client to <code>SimpleCallback</code>, <code>KerasCallback</code>, or <code>LightningCallback</code>.</li>
+        <li class="glass"><span>5</span>Run training and receive updates plus optional exported plots.</li>
+      </ol>
+    </section>
+
+    <section id="usage" class="section reveal">
       <div class="section-head center-text">
         <p class="eyebrow">Detailed callback usage</p>
         <h2>Drop-in examples for real projects</h2>
@@ -108,14 +157,20 @@ slackker.notify(event="training_complete", status="completed")</code></pre>
             <span class="ide-dot dot-yellow"></span>
             <span class="ide-dot dot-green"></span>
             <span class="ide-filename">pipeline.py</span>
+            <div class="platform-toggle" role="group" aria-label="Switch client">
+              <span class="platform-label">Client: </span>
+              <button class="plt-btn active" data-platform="telegram">Telegram</button>
+              <button class="plt-btn" data-platform="slack">Slack</button>
+            </div>
           </div>
-<pre><code>from slackker.callbacks.basic import SlackUpdate
+<pre><code class="code-python" data-snippet="basic">from slackker.core import TelegramClient
+from slackker.callbacks.simple import SimpleCallback
 
-notify = SlackUpdate(
-    token="xoxb-your-bot-token",
-    channel="A04AAB77ABC",
+client = TelegramClient(
+    token="123456:ABC-DEF...",
     verbose=1
 )
+notify = SimpleCallback(client)
 
 @notify.notifier
 def run_data_pipeline(source_path: str):
@@ -139,16 +194,24 @@ if __name__ == "__main__":
             <span class="ide-dot dot-yellow"></span>
             <span class="ide-dot dot-green"></span>
             <span class="ide-filename">train_keras.py</span>
+            <div class="platform-toggle" role="group" aria-label="Switch client">
+              <span class="platform-label">Client: </span>
+              <button class="plt-btn active" data-platform="telegram">Telegram</button>
+              <button class="plt-btn" data-platform="slack">Slack</button>
+            </div>
           </div>
-<pre><code>from slackker.callbacks.keras import SlackUpdate
+<pre><code class="code-python" data-snippet="keras">from slackker.core import TelegramClient
+from slackker.callbacks.keras import KerasCallback
 
-slackker_cb = SlackUpdate(
-    token="xoxb-your-bot-token",
-    channel="A04AAB77ABC",
-    ModelName="ImageClassifierV1",
-    export="png",
-    SendPlot=True,
+client = TelegramClient(
+    token="123456:ABC-DEF...",
     verbose=1
+)
+slackker_cb = KerasCallback(
+    client=client,
+    model_name="ImageClassifierV1",
+    export="png",
+    send_plot=True,
 )
 
 history = model.fit(
@@ -167,19 +230,27 @@ history = model.fit(
             <span class="ide-dot dot-yellow"></span>
             <span class="ide-dot dot-green"></span>
             <span class="ide-filename">train_lightning.py</span>
+            <div class="platform-toggle" role="group" aria-label="Switch client">
+              <span class="platform-label">Client: </span>
+              <button class="plt-btn active" data-platform="telegram">Telegram</button>
+              <button class="plt-btn" data-platform="slack">Slack</button>
+            </div>
           </div>
-<pre><code>from lightning.pytorch import Trainer
-from slackker.callbacks.lightning import SlackUpdate
+<pre><code class="code-python" data-snippet="lightning">from lightning.pytorch import Trainer
+from slackker.core import TelegramClient
+from slackker.callbacks.lightning import LightningCallback
 
-slackker_cb = SlackUpdate(
-    token="xoxb-your-bot-token",
-    channel="A04AAB77ABC",
-    ModelName="LightningClassifier",
-    TrackLogs=["train_loss", "train_acc", "val_loss", "val_acc"],
+client = TelegramClient(
+    token="123456:ABC-DEF...",
+    verbose=1
+)
+slackker_cb = LightningCallback(
+    client=client,
+    model_name="LightningClassifier",
+    track_logs=["train_loss", "train_acc", "val_loss", "val_acc"],
     monitor="val_loss",
     export="png",
-    SendPlot=True,
-    verbose=1
+    send_plot=True,
 )
 
 trainer = Trainer(max_epochs=12, callbacks=[slackker_cb])
@@ -188,17 +259,59 @@ trainer.fit(model, train_loader, val_loader)</code></pre>
       </div>
     </section>
 
-    <section id="quickstart" class="section reveal quickstart-section">
+    <section id="how-it-works" class="section reveal">
       <div class="section-head center-text">
-        <p class="eyebrow">Quick start</p>
-        <h2>From install to updates in four steps</h2>
+        <p class="eyebrow">Under the hood</p>
+        <h2>Three lines to stay in the loop</h2>
       </div>
-      <ol class="steps center-block">
-        <li class="glass"><span>1</span>Install package: <strong>pip install slackker</strong></li>
-        <li class="glass"><span>2</span>Setup Slack app token and channel, or Telegram token.</li>
-        <li class="glass"><span>3</span>Create callback object and attach notifier/decorator.</li>
-        <li class="glass"><span>4</span>Run training and receive updates plus optional exported plots.</li>
-      </ol>
+      <div class="hiw-steps">
+
+        <div class="hiw-step glass">
+          <div class="hiw-icon">🔌</div>
+          <div class="hiw-num">01</div>
+          <h3>Connect</h3>
+          <p>Create a <strong>SlackClient</strong> or <strong>TelegramClient</strong> with your API token. slackker verifies connectivity and resolves your channel or chat ID automatically.</p>
+        </div>
+
+        <div class="hiw-arrow" aria-hidden="true">
+          <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
+        </div>
+
+        <div class="hiw-step glass">
+          <div class="hiw-icon">🎯</div>
+          <div class="hiw-num">02</div>
+          <h3>Attach</h3>
+          <p>Pass the client to <strong>SimpleCallback</strong>, <strong>KerasCallback</strong>, or <strong>LightningCallback</strong>. Wrap your function with <code>@notifier</code> or drop the callback into your trainer.</p>
+        </div>
+
+        <div class="hiw-arrow" aria-hidden="true">
+          <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
+        </div>
+
+        <div class="hiw-step glass">
+          <div class="hiw-icon">📲</div>
+          <div class="hiw-num">03</div>
+          <h3>Receive</h3>
+          <p>Get real-time updates — execution time, returned outputs, epoch metrics, best model stats, and optional training plots — delivered straight to your phone.</p>
+        </div>
+
+      </div>
+    </section>
+
+    <section id="cta" class="section reveal cta-section">
+      <div class="cta-card glass">
+        <img src="assets/slackker_logo_medium_alpha.png" alt="slackker logo" class="cta-logo" />
+        <p class="eyebrow">Get started in 60 seconds</p>
+        <h2>Your pipeline runs. Your phone <span class="highlight">notifies</span></h2>
+        <p class="cta-sub">Stop babysitting terminal. Slackker keeps you informed so you can stay heads-down on what actually matters.</p>
+        <div class="cta-actions center-wrap">
+          <a class="btn btn-ghost" href="https://github.com/siddheshgunjal/slackker" target="_blank" rel="noreferrer">
+            <svg width="20" height="20" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
+            View on GitHub
+          </a>
+          <a class="btn btn-primary" href="https://pypi.org/project/slackker/" target="_blank" rel="noreferrer">pip install slackker</a>
+        </div>
+      </div>
     </section>
   </main>
 
@@ -207,7 +320,7 @@ trainer.fit(model, train_loader, val_loader)</code></pre>
     <div class="footer-bar">
       <div class="footer-status">
         <span class="footer-pulse"></span>
-        <span>slackker v1.2.38</span>
+        <span>slackker v1.3.0</span>
       </div>
       <div class="footer-links">
         <a href="https://github.com/siddheshgunjal/slackker" target="_blank" rel="noreferrer">GitHub</a>

--- a/website/script.js
+++ b/website/script.js
@@ -59,3 +59,238 @@ function activateTab(targetId) {
 tabs.forEach((tab) => {
   tab.addEventListener("click", () => activateTab(tab.dataset.target));
 });
+
+function escapeHtml(text) {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+function highlightPython(codeText) {
+  let code = escapeHtml(codeText);
+  const placeholders = [];
+
+  const stash = (regex, tokenClass) => {
+    code = code.replace(regex, (match) => {
+      const idx = placeholders.push(`<span class="${tokenClass}">${match}</span>`) - 1;
+      return `@@HL${idx}@@`;
+    });
+  };
+
+  // Protect strings/comments from later substitutions.
+  stash(/("""[\s\S]*?"""|'''[\s\S]*?'''|"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*')/g, "tok-string");
+  stash(/#.*/g, "tok-comment");
+
+  code = code.replace(/(^\s*)(@[A-Za-z_][\w.]*)/gm, "$1<span class=\"tok-decorator\">$2</span>");
+  code = code.replace(/\b(def|class)\s+([A-Za-z_][A-Za-z0-9_]*)\b/g, (m, kw, name) => {
+    return `<span class="tok-keyword">${kw}</span> <span class="tok-function">${name}</span>`;
+  });
+  code = code.replace(/\b(from|import|as|if|elif|else|for|while|return|try|except|finally|with|in|pass|raise|break|continue|lambda|and|or|not|is|yield|await|async|global|nonlocal|assert|del)\b/g, "<span class=\"tok-keyword\">$1</span>");
+  code = code.replace(/\b(True|False|None|self)\b/g, "<span class=\"tok-builtin\">$1</span>");
+  code = code.replace(/\b\d+(?:\.\d+)?\b/g, "<span class=\"tok-number\">$&</span>");
+
+  code = code.replace(/@@HL(\d+)@@/g, (_, idx) => placeholders[Number(idx)]);
+  return code;
+}
+
+function applyPythonHighlighting() {
+  document.querySelectorAll("code.code-python").forEach((block) => {
+    block.innerHTML = highlightPython(block.textContent || "");
+  });
+}
+
+applyPythonHighlighting();
+
+// ── Platform toggle ───────────────────────────────────────────
+
+const CODE_SNIPPETS = {
+  hero: {
+    telegram:
+`from slackker.core import TelegramClient
+from slackker.callbacks.simple import SimpleCallback
+
+client = TelegramClient(token="123456:ABC-DEF...")
+slackker = SimpleCallback(client)
+
+@slackker.notifier
+def train_model():
+    return "done"
+
+slackker.notify(event="training_complete", status="completed")`,
+    slack:
+`from slackker.core import SlackClient
+from slackker.callbacks.simple import SimpleCallback
+
+client = SlackClient(token="xoxb-...", channel="A04AAB77ABC")
+slackker = SimpleCallback(client)
+
+@slackker.notifier
+def train_model():
+    return "done"
+
+slackker.notify(event="training_complete", status="completed")`,
+  },
+  basic: {
+    telegram:
+`from slackker.core import TelegramClient
+from slackker.callbacks.simple import SimpleCallback
+
+client = TelegramClient(
+    token="123456:ABC-DEF...",
+    verbose=1
+)
+notify = SimpleCallback(client)
+
+@notify.notifier
+def run_data_pipeline(source_path: str):
+    rows_processed = 12500
+    status = "success"
+    return rows_processed, status
+
+if __name__ == "__main__":
+    rows, status = run_data_pipeline("./data/train.csv")
+    notify.notify(
+        event="pipeline_finished",
+        rows_processed=rows,
+        status=status,
+        attachment="./artifacts/summary.txt"
+    )`,
+    slack:
+`from slackker.core import SlackClient
+from slackker.callbacks.simple import SimpleCallback
+
+client = SlackClient(
+    token="xoxb-your-bot-token",
+    channel="A04AAB77ABC",
+    verbose=1
+)
+notify = SimpleCallback(client)
+
+@notify.notifier
+def run_data_pipeline(source_path: str):
+    rows_processed = 12500
+    status = "success"
+    return rows_processed, status
+
+if __name__ == "__main__":
+    rows, status = run_data_pipeline("./data/train.csv")
+    notify.notify(
+        event="pipeline_finished",
+        rows_processed=rows,
+        status=status,
+        attachment="./artifacts/summary.txt"
+    )`,
+  },
+  keras: {
+    telegram:
+`from slackker.core import TelegramClient
+from slackker.callbacks.keras import KerasCallback
+
+client = TelegramClient(
+    token="123456:ABC-DEF...",
+    verbose=1
+)
+slackker_cb = KerasCallback(
+    client=client,
+    model_name="ImageClassifierV1",
+    export="png",
+    send_plot=True,
+)
+
+history = model.fit(
+    x_train,
+    y_train,
+    epochs=20,
+    batch_size=32,
+    validation_data=(x_val, y_val),
+    callbacks=[slackker_cb]
+)`,
+    slack:
+`from slackker.core import SlackClient
+from slackker.callbacks.keras import KerasCallback
+
+client = SlackClient(
+    token="xoxb-your-bot-token",
+    channel="A04AAB77ABC",
+    verbose=1
+)
+slackker_cb = KerasCallback(
+    client=client,
+    model_name="ImageClassifierV1",
+    export="png",
+    send_plot=True,
+)
+
+history = model.fit(
+    x_train,
+    y_train,
+    epochs=20,
+    batch_size=32,
+    validation_data=(x_val, y_val),
+    callbacks=[slackker_cb]
+)`,
+  },
+  lightning: {
+    telegram:
+`from lightning.pytorch import Trainer
+from slackker.core import TelegramClient
+from slackker.callbacks.lightning import LightningCallback
+
+client = TelegramClient(
+    token="123456:ABC-DEF...",
+    verbose=1
+)
+slackker_cb = LightningCallback(
+    client=client,
+    model_name="LightningClassifier",
+    track_logs=["train_loss", "train_acc", "val_loss", "val_acc"],
+    monitor="val_loss",
+    export="png",
+    send_plot=True,
+)
+
+trainer = Trainer(max_epochs=12, callbacks=[slackker_cb])
+trainer.fit(model, train_loader, val_loader)`,
+    slack:
+`from lightning.pytorch import Trainer
+from slackker.core import SlackClient
+from slackker.callbacks.lightning import LightningCallback
+
+client = SlackClient(
+    token="xoxb-your-bot-token",
+    channel="A04AAB77ABC",
+    verbose=1
+)
+slackker_cb = LightningCallback(
+    client=client,
+    model_name="LightningClassifier",
+    track_logs=["train_loss", "train_acc", "val_loss", "val_acc"],
+    monitor="val_loss",
+    export="png",
+    send_plot=True,
+)
+
+trainer = Trainer(max_epochs=12, callbacks=[slackker_cb])
+trainer.fit(model, train_loader, val_loader)`,
+  },
+};
+
+document.querySelectorAll(".platform-toggle").forEach((toggle) => {
+  toggle.querySelectorAll(".plt-btn").forEach((btn) => {
+    btn.addEventListener("click", () => {
+      const platform = btn.dataset.platform;
+      const container = toggle.closest(".hero-code, .example-panel");
+      const codeBlock = container.querySelector("code.code-python");
+      const snippet = codeBlock.dataset.snippet;
+
+      if (!CODE_SNIPPETS[snippet]?.[platform]) return;
+
+      toggle.querySelectorAll(".plt-btn").forEach((b) =>
+        b.classList.toggle("active", b === btn)
+      );
+
+      codeBlock.innerHTML = highlightPython(CODE_SNIPPETS[snippet][platform]);
+    });
+  });
+});

--- a/website/styles.css
+++ b/website/styles.css
@@ -51,7 +51,7 @@ body {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0.8rem 1rem;
+  padding: 0.5rem 1rem;
   position: sticky;
   top: 0.9rem;
   z-index: 20;
@@ -70,15 +70,19 @@ body {
 }
 
 .brand img {
-  width: 40px;
-  height: 40px;
+  width: 55px;
+  height: 55px;
   border-radius: 0.7rem;
+}
+
+.brand span {
+  font-size: 1.5rem;
 }
 
 .nav-links {
   display: flex;
   align-items: center;
-  gap: 1rem;
+  gap: 1.2rem;
 }
 
 .nav-links a {
@@ -213,8 +217,29 @@ h2 {
 }
 
 .card {
-  padding: 1rem;
-  min-height: 172px;
+  padding: 1.2rem 1rem;
+  min-height: 220px;
+}
+
+.card-icon {
+  width: 52px;
+  height: 52px;
+  margin: 0 auto 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.card-icon svg {
+  width: 52px;
+  height: 52px;
+  object-fit: contain;
+}
+
+.card-icon img {
+  width: 75px;
+  height: 75px;
+  object-fit: contain;
 }
 
 .example-switch {
@@ -252,7 +277,7 @@ h2 {
   align-items: center;
   gap: 0.45rem;
   padding: 0.6rem 0.9rem;
-  background: rgba(0, 0, 0, 0.3);
+  background: rgba(0, 0, 0, 0.72);
   border-bottom: 1px solid rgba(255, 255, 255, 0.07);
 }
 
@@ -269,26 +294,108 @@ h2 {
 
 .ide-filename {
   margin-left: 0.55rem;
-  font-size: 0.76rem;
-  font-family: "JetBrains Mono", "Fira Code", monospace;
-  color: rgb(11, 30, 26);
+  font-size: 0.85rem;
+  font-family: "JetBrains Mono", "CaskaydiaCove", monospace;
+  color: #ffffff;
   letter-spacing: 0.02em;
+}
+
+.platform-label {
+  font-size: 0.85rem;
+  color: #ffffff;
+  font-family: "JetBrains Mono", "CaskaydiaCove", monospace;
+  vertical-align: middle;
+}
+
+.platform-toggle {
+  display: flex;
+  align-items: center;
+  margin-left: auto;
+  gap: 0.25rem;
+}
+
+.plt-btn {
+  font-size: 0.72rem;
+  font-weight: 700;
+  font-family: "Manrope", sans-serif;
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(255, 255, 255, 0.12);
+  color: rgba(255, 255, 255, 0.6);
+  cursor: pointer;
+  transition: background 0.18s ease, color 0.18s ease;
+  line-height: 1.4;
+}
+
+.plt-btn:hover {
+  background: rgba(255, 255, 255, 0.22);
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.plt-btn.active {
+  background: linear-gradient(135deg, var(--teal), var(--teal-2));
+  color: #ffffff;
+  border-color: transparent;
 }
 
 .hero-code pre,
 .example-panel pre {
-  background: #0b1e1a;
-  color: #9efce5;
-  padding: 1.2rem;
   margin: 0;
+  border-radius: 0 0 0.75rem 0.75rem;
+}
+
+.hero-code code.code-python,
+.example-panel code.code-python {
+  display: block;
+  min-width: 100%;
+  padding: 1.2rem;
+  background: #000000;
+  color: #e8fff8;
+  white-space: pre;
+}
+
+.hero-code .tok-keyword,
+.example-panel .tok-keyword {
+  color: #e879f9;
+}
+
+.hero-code .tok-string,
+.example-panel .tok-string {
+  color: #a8ff78;
+}
+
+.hero-code .tok-comment,
+.example-panel .tok-comment {
+  color: #6b7f8a;
+  font-style: italic;
+}
+
+.hero-code .tok-number,
+.example-panel .tok-number {
+  color: #ff9a5c;
+}
+
+.hero-code .tok-decorator,
+.example-panel .tok-decorator {
+  color: #60a5fa;
+}
+
+.hero-code .tok-builtin,
+.example-panel .tok-builtin {
+  color: #ffd93d;
+}
+
+.hero-code .tok-function,
+.example-panel .tok-function {
+  color: #34ffe0;
 }
 
 pre {
   margin: 0;
-  padding: 1.1rem;
+  padding: 0;
   overflow-x: auto;
-  color: var(--text);
-  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-family: "JetBrains Mono", "CaskaydiaCove", monospace;
   font-size: 0.88rem;
   line-height: 1.55;
 }
@@ -313,22 +420,39 @@ pre {
 }
 
 .steps li {
-  display: flex;
-  align-items: center;
-  gap: 0.85rem;
+  display: block;
   padding: 0.85rem 1rem;
+  line-height: 1.6;
+}
+
+.steps li code {
+  font-family: "JetBrains Mono", "CaskaydiaCove", monospace;
+  font-size: 0.85em;
+  background: rgba(0, 255, 180, 0.1);
+  color: var(--text);
+  padding: 0.1em 0.4em;
+  border-radius: 4px;
+  border: 1px solid rgba(0, 255, 180, 0.2);
 }
 
 .steps li span {
+  display: inline-grid;
+  place-items: center;
   width: 28px;
   height: 28px;
   border-radius: 999px;
-  display: inline-grid;
-  place-items: center;
   background: linear-gradient(135deg, var(--teal), var(--accent));
   color: #ffffff;
   font-size: 0.85rem;
   font-weight: 800;
+  margin-right: 0.6rem;
+  vertical-align: middle;
+}
+
+.cta-logo {
+  width: 90px;
+  height: 90px;
+  margin-bottom: 0.1rem;
 }
 
 .footer {
@@ -350,7 +474,7 @@ pre {
   flex-wrap: wrap;
   gap: 0.75rem;
   font-size: 0.78rem;
-  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-family: "JetBrains Mono", "CaskaydiaCove", monospace;
   color: var(--muted);
   text-align: center;
 }
@@ -437,6 +561,7 @@ pre {
 
   .menu-btn {
     display: inline-flex;
+    font-size: 1rem;
   }
 
   .footer-bar {
@@ -476,5 +601,264 @@ pre {
 
   .cards {
     grid-template-columns: 1fr;
+  }
+
+  /* ── Code blocks ─────────────────────────────────────────── */
+  .hero-code {
+    max-width: 100%;
+    margin-left: -0.25rem;
+    margin-right: -0.25rem;
+  }
+
+  .hero-code code.code-python,
+  .example-panel code.code-python {
+    font-size: 0.75rem;
+    padding: 1rem 0.85rem;
+    white-space: pre;
+    overflow-x: auto;
+    display: block;
+    max-width: 100%;
+  }
+
+  .hero-code pre,
+  .example-panel pre {
+    overflow-x: auto;
+    max-width: 100%;
+  }
+
+  /* ── Example panels ──────────────────────────────────────── */
+  .example-panels {
+    max-width: 100%;
+  }
+
+  .example-panel {
+    max-width: 100%;
+    overflow-x: hidden;
+  }
+
+  .example-switch {
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  .example-tab {
+    font-size: 0.82rem;
+    padding: 0.45rem 0.75rem;
+  }
+
+  /* ── Quickstart steps ────────────────────────────────────── */
+  .steps {
+    max-width: 100%;
+  }
+
+  .steps li {
+    font-size: 0.88rem;
+    padding: 0.75rem 0.85rem;
+  }
+
+  .steps li code {
+    font-size: 0.78em;
+    word-break: break-word;
+  }
+
+  /* ── Buttons ─────────────────────────────────────────────── */
+  .hero-cta {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.65rem;
+    width: 100%;
+    max-width: 320px;
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  .btn {
+    width: 100%;
+    justify-content: center;
+    padding: 0.8rem 1rem;
+  }
+
+  /* ── Section spacing ─────────────────────────────────────── */
+  .section {
+    padding: 2rem 0;
+  }
+
+  .section-head {
+    margin-bottom: 1rem;
+  }
+}
+
+@media (max-width: 480px) {
+  body {
+    padding: 0.5rem;
+  }
+
+  .topbar {
+    padding: 0.6rem 0.75rem;
+    top: 0.4rem;
+  }
+
+  .hero {
+    padding-top: 1rem;
+    padding-bottom: 1rem;
+  }
+
+  h1 {
+    font-size: clamp(1.75rem, 9vw, 2.5rem);
+  }
+
+  .lead {
+    font-size: 0.92rem;
+  }
+
+  .hero-code code.code-python,
+  .example-panel code.code-python {
+    font-size: 0.7rem;
+    padding: 0.85rem 0.7rem;
+  }
+
+  .ide-titlebar {
+    gap: 0.3rem;
+  }
+
+  .ide-filename {
+    font-size: 0.75rem;
+  }
+
+  .platform-label {
+    font-size: 0.68rem;
+  }
+
+  .plt-btn {
+    font-size: 0.68rem;
+  }
+
+  .steps li {
+    font-size: 0.82rem;
+    padding: 0.65rem 0.7rem;
+  }
+
+  .steps li span {
+    width: 24px;
+    height: 24px;
+    font-size: 0.75rem;
+  }
+}
+
+/* ── How it works ───────────────────────────────────────────── */
+.hiw-steps {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.8rem;
+  max-width: 980px;
+  margin: 0 auto;
+}
+
+.hiw-step {
+  flex: 1;
+  padding: 1.8rem 1.4rem;
+  position: relative;
+  text-align: center;
+}
+
+.hiw-icon {
+  font-size: 2rem;
+  line-height: 1;
+  margin-bottom: 0.65rem;
+}
+
+.hiw-num {
+  font-family: "Space Grotesk", sans-serif;
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  color: var(--teal);
+  text-transform: uppercase;
+  margin-bottom: 0.4rem;
+}
+
+.hiw-step h3 {
+  font-family: "Space Grotesk", sans-serif;
+  font-size: 1.15rem;
+  margin-bottom: 0.5rem;
+}
+
+.hiw-step p {
+  color: var(--muted);
+  font-size: 0.92rem;
+  margin: 0;
+}
+
+.hiw-step code {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.82em;
+  background: rgba(0, 255, 180, 0.1);
+  color: var(--teal);
+  padding: 0.1em 0.35em;
+  border-radius: 4px;
+  border: 1px solid rgba(0, 255, 180, 0.2);
+}
+
+.hiw-arrow {
+  color: var(--teal);
+  flex-shrink: 0;
+  opacity: 0.6;
+}
+
+/* ── CTA ────────────────────────────────────────────────────── */
+.cta-section {
+  padding-bottom: 1rem;
+}
+
+.cta-card {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 3.2rem 2.4rem;
+  text-align: center;
+  background:
+    linear-gradient(145deg, rgba(26,171,138,0.08), rgba(62,212,174,0.12));
+  border-color: rgba(26, 171, 138, 0.25);
+}
+
+.cta-card h2 {
+  font-size: clamp(1.75rem, 6vw, 2rem);
+  margin: 0.5rem 0 1rem;
+  line-height: 1.2;
+}
+
+.cta-sub {
+  color: var(--muted);
+  max-width: 52ch;
+  margin: 0 auto 1.8rem;
+  font-size: 1rem;
+}
+
+.cta-actions {
+  gap: 0.8rem;
+}
+
+.highlight {
+  color: var(--teal);
+  font-weight: 700;
+}
+
+/* ── How it works responsive ────────────────────────────────── */
+@media (max-width: 760px) {
+  .hiw-steps {
+    flex-direction: column;
+    gap: 0.6rem;
+  }
+
+  .hiw-arrow {
+    transform: rotate(90deg);
+  }
+
+  .hiw-step {
+    width: 100%;
+  }
+
+  .cta-card {
+    padding: 2rem 1.4rem;
   }
 }


### PR DESCRIPTION
# Change Log
## Core Architecture & API
- Added `BaseClient`, `SlackClient`, and `TelegramClient` for a unified, pluggable client backend
- Introduced async-first design with sync convenience wrappers (`_run_sync`) for scripts and notebooks
- Added `SimpleCallback` as the new generic callback for function/script notifications
- Refactored framework integrations into unified callbacks: `KerasCallback` and `LightningCallback`
- Callback constructors now accept a client object instead of raw token/channel arguments
- Added `async_notify()` for async contexts and file attachment support via `notify(attachment=...)`

---

## Backward Compatibility & Deprecations
- Legacy `Update`, `SlackUpdate`, and `TelegramUpdate` classes still work via compatibility shims
- `DeprecationWarning` emitted on all legacy class instantiations with migration hints
- Deprecated utility modules forward to their replacements:
  - `utils.checkker` → `utils.network`
  - `utils.functions` → `core` clients + `utils.plotting`
  - `utils.ccolors` → `utils.logger`

---

## Utilities & Internals
- Added `utils/logger.py` — centralized logging via `loguru` with `[slackker]` prefixed output
- Added `utils/network.py` — async connectivity checks, Slack token verification, and Telegram chat ID discovery
- Added `utils/plotting.py` — reusable metric graph generation extracted from legacy helpers
- Updated `slackker/__init__.py` and `slackker/core/__init__.py` with clean public exports

---

## Tests
- Added `test_core.py` — unit tests for `BaseClient`, `SlackClient`, `TelegramClient`, and `_run_sync`
- Added `test_basic.py` — tests for `SimpleCallback`, `notifier` decorator, `notify()`, and legacy shims
- Added `test_keras.py` and `test_lightning.py` — lifecycle tests for new callbacks and backward-compat layers
- Added `pytest.ini` configuration and `tests/README.md` documenting the mocking strategy
- Added `run_tests.sh` helper for uv-based local test runs with coverage

---

## Documentation & Website
- Overhauled README to reflect the new client-based API with full code examples for all callbacks
- Updated installation instructions to prefer `uv`
- Website enhancements: new UI elements, code highlighting, and improved responsiveness