### PR TITLE
Configurable connectivity_url for platform reachability checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ So now you don't have to sit in front of the machine all the time. You can quick
 * [Maintainer](#maintainer-sunglasses)
 
 # Installation :arrow_down:
-* Install slackker from [UV][uv] is recommended. slackker is compatible with `Python >= 3.10` and runs on Linux, MacOS X and Windows. 
+* Install slackker from [UV][uv] is recommended. slackker is compatible with `Python >= 3.11` and runs on Linux, MacOS X and Windows. 
 * Installing slackker in your environment is easy. Just use below command:
 
 ```sh
@@ -51,7 +51,7 @@ uv add slackker
 ```
 
 OR
-```
+```sh
 pip install slackker
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "slackker"
-version = "1.3.0"
+version = "1.3.1"
 description = "Python package for monitoring your python script & Model training status in real-time on slack & telegram."
 readme = "README.md"
 requires-python = ">=3.11"
@@ -38,7 +38,7 @@ Changelog = "https://github.com/siddheshgunjal/slackker/releases"
 
 [tool.hatch.build.targets.wheel]
 include = ["slackker/**"]
-exclude = ["tests/**", "docs/**"]
+exclude = ["tests/**", "website/**"]
 [tool.hatch.version]
 path = "slackker/__init__.py"
 pattern = "__version__ = [\"'](.*?)[\"']"

--- a/slackker/__init__.py
+++ b/slackker/__init__.py
@@ -4,7 +4,7 @@ from slackker.callbacks.simple import SimpleCallback
 
 __author__ = 'Siddhesh Gunjal'
 __email__ = 'siddhu19@live.com'
-__version__ = '1.3.0'
+__version__ = '1.3.1'
 
 # module level doc-string
 __doc__ = """

--- a/slackker/callbacks/keras.py
+++ b/slackker/callbacks/keras.py
@@ -53,7 +53,7 @@ class KerasCallback(Callback):
             message += f", Validation Loss: {self.valid_loss[-1]:.4f}"
 
         connected = _run_sync(
-            network.check_connection_quick(url="www.slack.com" if self.client.platform == "slack" else "www.telegram.org")
+            network.check_connection_quick(url=self.client.connectivity_url)
         )
         if connected:
             self.client.send_message_sync(message)

--- a/slackker/callbacks/lightning.py
+++ b/slackker/callbacks/lightning.py
@@ -67,8 +67,7 @@ class LightningCallback(Callback):
         parts = [f"{key}: {metrics[key]:.4f}" for key in self.track_logs]
         message = f"Epoch: {self.n_epochs}, {', '.join(parts)}"
 
-        url = "www.slack.com" if self.client.platform == "slack" else "www.telegram.org"
-        connected = _run_sync(network.check_connection_quick(url=url))
+        connected = _run_sync(network.check_connection_quick(url=self.client.connectivity_url))
         if connected:
             self.client.send_message_sync(message)
 

--- a/slackker/core/client.py
+++ b/slackker/core/client.py
@@ -39,6 +39,12 @@ class BaseClient(ABC):
         """Return True if the client has successfully connected (token verified, chat_id known, etc.)."""
         ...
 
+    @property
+    @abstractmethod
+    def connectivity_url(self) -> str:
+        """Return the hostname used to check platform reachability, e.g. 'www.slack.com'."""
+        ...
+
     @abstractmethod
     async def send_message(self, text: str) -> None:
         """Send a text message to the configured channel."""

--- a/slackker/core/slack.py
+++ b/slackker/core/slack.py
@@ -30,6 +30,10 @@ class SlackClient(BaseClient):
     def is_connected(self) -> bool:
         return self._connected
 
+    @property
+    def connectivity_url(self) -> str:
+        return "www.slack.com"
+
     async def connect(self) -> bool:
         """Verify server connectivity and API token. Returns True on success."""
         server = await network.check_connection(url="www.slack.com", verbose=self._verbose)

--- a/slackker/core/telegram.py
+++ b/slackker/core/telegram.py
@@ -27,6 +27,10 @@ class TelegramClient(BaseClient):
         return self._chat_id is not None
 
     @property
+    def connectivity_url(self) -> str:
+        return "www.telegram.org"
+
+    @property
     def chat_id(self) -> str | None:
         return self._chat_id
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -27,6 +27,10 @@ class MockClient(BaseClient):
         return "mock"
 
     @property
+    def connectivity_url(self):
+        return "mock.example.com"
+
+    @property
     def is_connected(self):
         return True
 

--- a/tests/test_keras.py
+++ b/tests/test_keras.py
@@ -28,6 +28,10 @@ class MockClient(BaseClient):
         return self._platform_name
 
     @property
+    def connectivity_url(self):
+        return "mock.example.com"
+
+    @property
     def is_connected(self):
         return True
 

--- a/tests/test_lightning.py
+++ b/tests/test_lightning.py
@@ -29,6 +29,10 @@ class MockClient(BaseClient):
         return self._platform_name
 
     @property
+    def connectivity_url(self):
+        return "mock.example.com"
+
+    @property
     def is_connected(self):
         return True
 

--- a/uv.lock
+++ b/uv.lock
@@ -2308,7 +2308,7 @@ wheels = [
 
 [[package]]
 name = "slackker"
-version = "1.3.0"
+version = "1.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Enhancements
- Add `connectivity_url` property to `BaseClient` to define platform-specific reachability URLs.
- Refactor connection checking logic across clients to utilize the configurable `connectivity_url`.
- - Add `connectivity_url` property to test `MockClient` implementations in tests.

## Fix
- Update Python compatibility requirement from `>=3.10` to `>=3.11` in `README.md` and `pyproject.toml`.
- Update package exclusions in `pyproject.toml` from `docs/**` to `website/**`.
- Bump version from `1.3.0` to `1.3.1`.

