### PR TITLE
Fallback to ipv4 mechanism

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "httpx>=0.27.0",
     "aiohttp>=3.9.0",
     "requests>=2.31.0",
+    "nest-asyncio>=1.6.0",
 ]
 license = "Apache-2.0"
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "slackker"
-version = "1.4.1"
+version = "1.4.4"
 description = "Python package for monitoring your pipeline & Model training status in real-time on Slack, Telegram and Microsoft Teams."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/slackker/__init__.py
+++ b/slackker/__init__.py
@@ -4,7 +4,7 @@ from slackker.core import BaseClient, SlackClient, TeamsClient, TelegramClient
 
 __author__ = "Siddhesh Gunjal"
 __email__ = "siddhu19@live.com"
-__version__ = "1.4.1"
+__version__ = "1.4.4"
 
 # module level doc-string
 __doc__ = """

--- a/slackker/__init__.py
+++ b/slackker/__init__.py
@@ -1,10 +1,10 @@
 from slackker import callbacks
-from slackker.core import SlackClient, TelegramClient, TeamsClient, BaseClient
 from slackker.callbacks.simple import SimpleCallback
+from slackker.core import BaseClient, SlackClient, TeamsClient, TelegramClient
 
-__author__ = 'Siddhesh Gunjal'
-__email__ = 'siddhu19@live.com'
-__version__ = '1.4.1'
+__author__ = "Siddhesh Gunjal"
+__email__ = "siddhu19@live.com"
+__version__ = "1.4.1"
 
 # module level doc-string
 __doc__ = """

--- a/slackker/callbacks/__init__.py
+++ b/slackker/callbacks/__init__.py
@@ -1,4 +1,4 @@
+from slackker.callbacks.basic import SlackUpdate, TelegramUpdate, Update
 from slackker.callbacks.simple import SimpleCallback
-from slackker.callbacks.basic import Update, SlackUpdate, TelegramUpdate
 
 __all__ = ["SimpleCallback", "Update", "SlackUpdate", "TelegramUpdate"]

--- a/slackker/callbacks/basic.py
+++ b/slackker/callbacks/basic.py
@@ -5,6 +5,7 @@ This module is kept for backward compatibility only.
 """
 
 import warnings
+
 from slackker.callbacks.simple import SimpleCallback
 from slackker.core.client import _run_sync as _sync
 from slackker.core.slack import SlackClient
@@ -27,6 +28,7 @@ class Update(SimpleCallback):
 # ──────────────────────────────────────────────
 # Backward-compatible shims (deprecated)
 # ──────────────────────────────────────────────
+
 
 class SlackUpdate(SimpleCallback):
     """Deprecated: Use SimpleCallback(SlackClient(...)) instead."""

--- a/slackker/callbacks/keras.py
+++ b/slackker/callbacks/keras.py
@@ -1,21 +1,45 @@
 import warnings
 from datetime import datetime
+
 import numpy as np
 from keras.callbacks import Callback
+
 from slackker.core.client import BaseClient, _run_sync
-from slackker.utils.logger import log
 from slackker.utils import network, plotting
+from slackker.utils.logger import log
 
 
 class KerasCallback(Callback):
     """Unified Keras training callback that works with any client backend."""
 
-    SUPPORTED_FORMATS = ("eps", "jpeg", "jpg", "pdf", "pgf", "png", "ps", "raw", "rgba", "svg", "svgz", "tif", "tiff")
+    SUPPORTED_FORMATS = (
+        "eps",
+        "jpeg",
+        "jpg",
+        "pdf",
+        "pgf",
+        "png",
+        "ps",
+        "raw",
+        "rgba",
+        "svg",
+        "svgz",
+        "tif",
+        "tiff",
+    )
 
-    def __init__(self, client: BaseClient, model_name: str, export: str = "png", send_plot: bool = False):
+    def __init__(
+        self,
+        client: BaseClient,
+        model_name: str,
+        export: str = "png",
+        send_plot: bool = False,
+    ):
         super().__init__()
         if export not in self.SUPPORTED_FORMATS:
-            raise ValueError(f"Unsupported export format '{export}'. Supported: {self.SUPPORTED_FORMATS}")
+            raise ValueError(
+                f"Unsupported export format '{export}'. Supported: {self.SUPPORTED_FORMATS}"
+            )
 
         self.client = client
         self.model_name = model_name
@@ -72,7 +96,7 @@ class KerasCallback(Callback):
                 f"Trained for {self.n_epochs} epochs. Best epoch was {best_epoch}."
             )
             self.client.send_message_sync(
-                f"Best validation loss = {val_loss:.4f}, Training Loss = {train_loss:.4f}, Best Accuracy = {100*val_acc:.4f}%"
+                f"Best validation loss = {val_loss:.4f}, Training Loss = {train_loss:.4f}, Best Accuracy = {100 * val_acc:.4f}%"
             )
 
         training_logs = {
@@ -83,7 +107,9 @@ class KerasCallback(Callback):
         }
 
         if self.send_plot:
-            paths = plotting.generate_and_get_plots(self.model_name, self.export, training_logs)
+            paths = plotting.generate_and_get_plots(
+                self.model_name, self.export, training_logs
+            )
             for path in paths:
                 self.client.upload_image_sync(path, comment=f"{self.model_name} 📎")
 
@@ -99,7 +125,9 @@ from slackker.core.telegram import TelegramClient
 class SlackUpdate(KerasCallback):
     """Deprecated: Use KerasCallback(SlackClient(...), ...) instead."""
 
-    def __init__(self, token, channel, ModelName, export="png", SendPlot=False, verbose=0):
+    def __init__(
+        self, token, channel, ModelName, export="png", SendPlot=False, verbose=0
+    ):
         warnings.warn(
             "SlackUpdate is deprecated. Use KerasCallback(SlackClient(token, channel), model_name) instead.",
             DeprecationWarning,
@@ -115,7 +143,9 @@ class SlackUpdate(KerasCallback):
             log.error("Failed to connect to Slack.")
             return
 
-        super().__init__(client=client, model_name=ModelName, export=export, send_plot=SendPlot)
+        super().__init__(
+            client=client, model_name=ModelName, export=export, send_plot=SendPlot
+        )
 
         # Expose old attribute names for backward compat
         self.ModelName = ModelName
@@ -144,7 +174,9 @@ class TelegramUpdate(KerasCallback):
             log.error("Failed to connect to Telegram.")
             return
 
-        super().__init__(client=client, model_name=ModelName, export=export, send_plot=SendPlot)
+        super().__init__(
+            client=client, model_name=ModelName, export=export, send_plot=SendPlot
+        )
 
         # Expose old attribute names for backward compat
         self.ModelName = ModelName

--- a/slackker/callbacks/lightning.py
+++ b/slackker/callbacks/lightning.py
@@ -1,17 +1,33 @@
 import sys
 import warnings
 from datetime import datetime
+
 import numpy as np
 from lightning.pytorch.callbacks import Callback
+
 from slackker.core.client import BaseClient, _run_sync
-from slackker.utils.logger import log
 from slackker.utils import network, plotting
+from slackker.utils.logger import log
 
 
 class LightningCallback(Callback):
     """Unified Lightning training callback that works with any client backend."""
 
-    SUPPORTED_FORMATS = ("eps", "jpeg", "jpg", "pdf", "pgf", "png", "ps", "raw", "rgba", "svg", "svgz", "tif", "tiff")
+    SUPPORTED_FORMATS = (
+        "eps",
+        "jpeg",
+        "jpg",
+        "pdf",
+        "pgf",
+        "png",
+        "ps",
+        "raw",
+        "rgba",
+        "svg",
+        "svgz",
+        "tif",
+        "tiff",
+    )
 
     def __init__(
         self,
@@ -24,7 +40,9 @@ class LightningCallback(Callback):
     ):
         super().__init__()
         if export not in self.SUPPORTED_FORMATS:
-            raise ValueError(f"Unsupported export format '{export}'. Supported: {self.SUPPORTED_FORMATS}")
+            raise ValueError(
+                f"Unsupported export format '{export}'. Supported: {self.SUPPORTED_FORMATS}"
+            )
 
         if track_logs is None:
             log.error("Provide at least 1 log type for sending update.")
@@ -67,7 +85,9 @@ class LightningCallback(Callback):
         parts = [f"{key}: {metrics[key]:.4f}" for key in self.track_logs]
         message = f"Epoch: {self.n_epochs}, {', '.join(parts)}"
 
-        connected = _run_sync(network.check_connection_quick(url=self.client.connectivity_url))
+        connected = _run_sync(
+            network.check_connection_quick(url=self.client.connectivity_url)
+        )
         if connected:
             self.client.send_message_sync(message)
 
@@ -91,7 +111,9 @@ class LightningCallback(Callback):
         self.client.send_message_sync(message)
 
         if self.send_plot:
-            paths = plotting.generate_and_get_plots(self.model_name, self.export, self.training_logs)
+            paths = plotting.generate_and_get_plots(
+                self.model_name, self.export, self.training_logs
+            )
             for path in paths:
                 self.client.upload_image_sync(path, comment=f"{self.model_name} 📎")
 
@@ -107,7 +129,17 @@ from slackker.core.telegram import TelegramClient
 class SlackUpdate(LightningCallback):
     """Deprecated: Use LightningCallback(SlackClient(...), ...) instead."""
 
-    def __init__(self, token, channel, ModelName, TrackLogs=None, monitor=None, export="png", SendPlot=False, verbose=0):
+    def __init__(
+        self,
+        token,
+        channel,
+        ModelName,
+        TrackLogs=None,
+        monitor=None,
+        export="png",
+        SendPlot=False,
+        verbose=0,
+    ):
         warnings.warn(
             "SlackUpdate is deprecated. Use LightningCallback(SlackClient(token, channel), ...) instead.",
             DeprecationWarning,
@@ -144,7 +176,16 @@ class SlackUpdate(LightningCallback):
 class TelegramUpdate(LightningCallback):
     """Deprecated: Use LightningCallback(TelegramClient(...), ...) instead."""
 
-    def __init__(self, token, ModelName, TrackLogs=None, monitor=None, export="png", SendPlot=False, verbose=0):
+    def __init__(
+        self,
+        token,
+        ModelName,
+        TrackLogs=None,
+        monitor=None,
+        export="png",
+        SendPlot=False,
+        verbose=0,
+    ):
         warnings.warn(
             "TelegramUpdate is deprecated. Use LightningCallback(TelegramClient(token), ...) instead.",
             DeprecationWarning,

--- a/slackker/callbacks/simple.py
+++ b/slackker/callbacks/simple.py
@@ -1,7 +1,8 @@
-import time
 import os
-from inspect import stack
+import time
 from datetime import datetime
+from inspect import stack
+
 from slackker.core.client import BaseClient, _run_sync
 from slackker.utils.logger import log
 
@@ -20,9 +21,12 @@ class SimpleCallback:
 
     def notifier(self, function):
         """Decorator to log function calls and send execution reports."""
+
         def wrapper(*args, **kwargs):
             if self.client.verbose > 0:
-                log.info(f"Calling {function.__name__} with args: {args}, kwargs: {kwargs}")
+                log.info(
+                    f"Calling {function.__name__} with args: {args}, kwargs: {kwargs}"
+                )
 
             start_time = time.time()
             result = function(*args, **kwargs)
@@ -43,9 +47,12 @@ class SimpleCallback:
 
             self.client.send_message_sync(message)
             return result
+
         return wrapper
 
-    async def async_notify(self, event: str | None = None, attachment: str | None = None, **kwargs):
+    async def async_notify(
+        self, event: str | None = None, attachment: str | None = None, **kwargs
+    ):
         """Async notification method."""
         script = stack()[1].filename
         text = f"Notification: {event or os.path.basename(script)} at {datetime.now().strftime('%d-%m-%Y %H:%M:%S')}"

--- a/slackker/core/__init__.py
+++ b/slackker/core/__init__.py
@@ -1,6 +1,6 @@
 from slackker.core.client import BaseClient
 from slackker.core.slack import SlackClient
-from slackker.core.telegram import TelegramClient
 from slackker.core.teams import TeamsClient
+from slackker.core.telegram import TelegramClient
 
 __all__ = ["BaseClient", "SlackClient", "TelegramClient", "TeamsClient"]

--- a/slackker/core/client.py
+++ b/slackker/core/client.py
@@ -11,6 +11,7 @@ def _run_sync(coro):
 
     if loop and loop.is_running():
         import nest_asyncio
+
         nest_asyncio.apply()
         return loop.run_until_complete(coro)
     else:

--- a/slackker/core/slack.py
+++ b/slackker/core/slack.py
@@ -1,9 +1,11 @@
 import os
-from slack_sdk.web.async_client import AsyncWebClient
+
 from slack_sdk.errors import SlackApiError
+from slack_sdk.web.async_client import AsyncWebClient
+
 from slackker.core.client import BaseClient
-from slackker.utils.logger import log
 from slackker.utils import network
+from slackker.utils.logger import log
 
 
 class SlackClient(BaseClient):
@@ -36,7 +38,9 @@ class SlackClient(BaseClient):
 
     async def connect(self) -> bool:
         """Verify server connectivity and API token. Returns True on success."""
-        server = await network.check_connection(url="api.slack.com", verbose=self._verbose)
+        server = await network.check_connection(
+            url="api.slack.com", verbose=self._verbose
+        )
         api = await network.verify_slack_token(token=self._token, verbose=self._verbose)
         self._connected = server and api
         return self._connected

--- a/slackker/core/teams.py
+++ b/slackker/core/teams.py
@@ -229,7 +229,7 @@ class TeamsClient(BaseClient):
         url = f"{_GRAPH_BASE}/chats/{self._chat_id}/messages"
         payload = {"body": {"contentType": "text", "content": text}}
         try:
-            async with httpx.AsyncClient() as client:
+            async with network._make_async_client() as client:
                 resp = await client.post(url, json=payload, headers=self._auth_headers(), timeout=10)
                 resp.raise_for_status()
             if self._verbose >= 1:
@@ -262,7 +262,7 @@ class TeamsClient(BaseClient):
             with open(filepath, "rb") as f:
                 file_bytes = f.read()
 
-            async with httpx.AsyncClient() as client:
+            async with network._make_async_client() as client:
                 resp = await client.put(
                     upload_url,
                     content=file_bytes,

--- a/slackker/core/teams.py
+++ b/slackker/core/teams.py
@@ -1,11 +1,13 @@
 import json
 import os
 import time
-import httpx
 from pathlib import Path
+
+import httpx
+
 from slackker.core.client import BaseClient
-from slackker.utils.logger import log
 from slackker.utils import network
+from slackker.utils.logger import log
 
 _GRAPH_BASE = "https://graph.microsoft.com/v1.0"
 
@@ -137,11 +139,13 @@ class TeamsClient(BaseClient):
         self._access_token = token_data["access_token"]
         expires_in = int(token_data.get("expires_in", 3600))
         self._token_expiry = time.time() + expires_in - 300  # 5-min safety buffer
-        self._save_token_cache({
-            "access_token": token_data["access_token"],
-            "refresh_token": token_data.get("refresh_token", ""),
-            "expires_at": self._token_expiry,
-        })
+        self._save_token_cache(
+            {
+                "access_token": token_data["access_token"],
+                "refresh_token": token_data.get("refresh_token", ""),
+                "expires_at": self._token_expiry,
+            }
+        )
 
     # ── Connection ──────────────────────────────────────────────────────────
 
@@ -156,7 +160,9 @@ class TeamsClient(BaseClient):
            b. Poll until the user authenticates or the code expires.
         4. Cache the resulting token for future silent refreshes.
         """
-        server = await network.check_connection(url="graph.microsoft.com", verbose=self._verbose)
+        server = await network.check_connection(
+            url="graph.microsoft.com", verbose=self._verbose
+        )
         if not server:
             return False
 
@@ -230,12 +236,16 @@ class TeamsClient(BaseClient):
         payload = {"body": {"contentType": "text", "content": text}}
         try:
             async with network._make_async_client() as client:
-                resp = await client.post(url, json=payload, headers=self._auth_headers(), timeout=10)
+                resp = await client.post(
+                    url, json=payload, headers=self._auth_headers(), timeout=10
+                )
                 resp.raise_for_status()
             if self._verbose >= 1:
                 log.info("Teams: Message posted to personal chat.")
         except httpx.HTTPStatusError as e:
-            log.error(f"Teams: Error posting message ({e.response.status_code}): {e.response.text}")
+            log.error(
+                f"Teams: Error posting message ({e.response.status_code}): {e.response.text}"
+            )
         except Exception as e:
             log.error(f"Teams: Error posting message: {e}")
 
@@ -283,7 +293,9 @@ class TeamsClient(BaseClient):
             await self.send_message(message_text)
 
         except httpx.HTTPStatusError as e:
-            log.error(f"Teams: Error uploading file ({e.response.status_code}): {e.response.text}")
+            log.error(
+                f"Teams: Error uploading file ({e.response.status_code}): {e.response.text}"
+            )
         except Exception as e:
             log.error(f"Teams: Error uploading file: {e}")
 

--- a/slackker/core/telegram.py
+++ b/slackker/core/telegram.py
@@ -53,7 +53,7 @@ class TelegramClient(BaseClient):
             return
         url = f"{self._base_url}/sendMessage"
         try:
-            async with httpx.AsyncClient() as client:
+            async with network._make_async_client() as client:
                 response = await client.post(url, params={"chat_id": self._chat_id, "text": text})
                 response.raise_for_status()
             if self._verbose >= 1:
@@ -73,7 +73,7 @@ class TelegramClient(BaseClient):
                 log.error(f"Invalid file path: {filepath}")
                 return
             caption = comment or "Attachment 📎"
-            async with httpx.AsyncClient() as client:
+            async with network._make_async_client() as client:
                 with open(filepath, "rb") as f:
                     response = await client.post(
                         url,
@@ -98,7 +98,7 @@ class TelegramClient(BaseClient):
                 log.error(f"Invalid file path: {filepath}")
                 return
             caption = comment or "Attachment 📎"
-            async with httpx.AsyncClient() as client:
+            async with network._make_async_client() as client:
                 with open(filepath, "rb") as f:
                     response = await client.post(
                         url,

--- a/slackker/core/telegram.py
+++ b/slackker/core/telegram.py
@@ -1,8 +1,10 @@
 import os
+
 import httpx
+
 from slackker.core.client import BaseClient
-from slackker.utils.logger import log
 from slackker.utils import network
+from slackker.utils.logger import log
 
 
 class TelegramClient(BaseClient):
@@ -36,7 +38,9 @@ class TelegramClient(BaseClient):
 
     async def connect(self) -> bool:
         """Verify server connectivity and discover chat_id if not provided."""
-        server = await network.check_connection(url="api.telegram.org", verbose=self._verbose)
+        server = await network.check_connection(
+            url="api.telegram.org", verbose=self._verbose
+        )
         if not server:
             return False
 
@@ -49,12 +53,16 @@ class TelegramClient(BaseClient):
 
     async def send_message(self, text: str) -> None:
         if not self._chat_id:
-            log.error("chat_id is not set. Call `await client.connect()` before sending messages.")
+            log.error(
+                "chat_id is not set. Call `await client.connect()` before sending messages."
+            )
             return
         url = f"{self._base_url}/sendMessage"
         try:
             async with network._make_async_client() as client:
-                response = await client.post(url, params={"chat_id": self._chat_id, "text": text})
+                response = await client.post(
+                    url, params={"chat_id": self._chat_id, "text": text}
+                )
                 response.raise_for_status()
             if self._verbose >= 1:
                 log.debug("Posted update on Telegram")
@@ -65,7 +73,9 @@ class TelegramClient(BaseClient):
 
     async def upload_file(self, filepath: str, comment: str | None = None) -> None:
         if not self._chat_id:
-            log.error("chat_id is not set. Call `await client.connect()` before uploading files.")
+            log.error(
+                "chat_id is not set. Call `await client.connect()` before uploading files."
+            )
             return
         url = f"{self._base_url}/sendDocument"
         try:
@@ -90,7 +100,9 @@ class TelegramClient(BaseClient):
 
     async def upload_image(self, filepath: str, comment: str | None = None) -> None:
         if not self._chat_id:
-            log.error("chat_id is not set. Call `await client.connect()` before uploading images.")
+            log.error(
+                "chat_id is not set. Call `await client.connect()` before uploading images."
+            )
             return
         url = f"{self._base_url}/sendPhoto"
         try:

--- a/slackker/utils/ccolors.py
+++ b/slackker/utils/ccolors.py
@@ -6,13 +6,14 @@ warnings.warn(
     stacklevel=2,
 )
 
+
 class colors:
-	# Assign colors to logging statements
-	def prRed(sent):
-		print("\033[91m {}\033[00m" .format(sent))
+    # Assign colors to logging statements
+    def prRed(sent):
+        print("\033[91m {}\033[00m".format(sent))
 
-	def prCyan(sent):
-		print("\033[96m {}\033[00m" .format(sent))
+    def prCyan(sent):
+        print("\033[96m {}\033[00m".format(sent))
 
-	def prYellow(sent):
-		print("\033[93m {}\033[00m" .format(sent))
+    def prYellow(sent):
+        print("\033[93m {}\033[00m".format(sent))

--- a/slackker/utils/checkker.py
+++ b/slackker/utils/checkker.py
@@ -1,11 +1,12 @@
 """Deprecated: Use slackker.utils.network instead."""
 
 import warnings
+
 from slackker.utils.network import (
-    check_connection_sync,
     check_connection_quick_sync,
-    verify_slack_token_sync,
+    check_connection_sync,
     get_telegram_chat_id_sync,
+    verify_slack_token_sync,
 )
 
 warnings.warn(

--- a/slackker/utils/functions.py
+++ b/slackker/utils/functions.py
@@ -1,7 +1,8 @@
 """Deprecated: Use slackker.core and slackker.utils.plotting instead."""
 
-import warnings
 import os
+import warnings
+
 from slackker.utils.logger import log
 from slackker.utils.plotting import generate_plot
 
@@ -16,11 +17,16 @@ class Plotter:
     """Deprecated: Use slackker.utils.plotting and client.upload_file() instead."""
 
     @staticmethod
-    def slack_file_upload(name, client, channel, filepath, initial_comment=None, verbose=1):
+    def slack_file_upload(
+        name, client, channel, filepath, initial_comment=None, verbose=1
+    ):
         from slack_sdk.errors import SlackApiError
+
         try:
             comment = initial_comment if initial_comment is not None else f"{name} 📎"
-            client.files_upload_v2(channel=channel, file=filepath, initial_comment=comment)
+            client.files_upload_v2(
+                channel=channel, file=filepath, initial_comment=comment
+            )
             if verbose >= 1:
                 log.debug(f"Uploaded attachment on {channel} channel")
         except SlackApiError as e:
@@ -29,9 +35,14 @@ class Plotter:
     @staticmethod
     def telegram_img_upload(name, token, channel, image, verbose=1):
         import requests
+
         url = f"https://api.telegram.org/bot{token}/sendPhoto"
         try:
-            requests.post(url, params={"chat_id": channel, "caption": f"{name} 📎"}, files={"photo": image})
+            requests.post(
+                url,
+                params={"chat_id": channel, "caption": f"{name} 📎"},
+                files={"photo": image},
+            )
             if verbose >= 1:
                 log.debug("Uploaded attachment on Telegram")
         except Exception as e:
@@ -40,24 +51,43 @@ class Plotter:
     @staticmethod
     def telegram_file_upload(name, token, channel, file, caption=None, verbose=1):
         import requests
+
         url = f"https://api.telegram.org/bot{token}/sendDocument"
         try:
             tg_caption = caption if caption is not None else f"{name} 📎"
-            requests.post(url, params={"chat_id": channel, "caption": tg_caption}, files={"document": file})
+            requests.post(
+                url,
+                params={"chat_id": channel, "caption": tg_caption},
+                files={"document": file},
+            )
             if verbose >= 1:
                 log.debug("Uploaded attachment on Telegram")
         except Exception as e:
             log.error(f"Error uploading attachment: {e}")
 
     @staticmethod
-    def plot_and_upload(platform, ModelName, export, client, channel, SendPlot, logs, metric, verbose=1):
+    def plot_and_upload(
+        platform, ModelName, export, client, channel, SendPlot, logs, metric, verbose=1
+    ):
         path = generate_plot(ModelName, export, logs, metric)
         if path and SendPlot:
             try:
                 if platform == "slack":
-                    Plotter.slack_file_upload(name=f"{ModelName}_{metric}", client=client, channel=channel, filepath=path, verbose=verbose)
+                    Plotter.slack_file_upload(
+                        name=f"{ModelName}_{metric}",
+                        client=client,
+                        channel=channel,
+                        filepath=path,
+                        verbose=verbose,
+                    )
                 else:
-                    Plotter.telegram_img_upload(name=f"{ModelName}_{metric}", token=client, channel=channel, image=open(path, "rb"), verbose=verbose)
+                    Plotter.telegram_img_upload(
+                        name=f"{ModelName}_{metric}",
+                        token=client,
+                        channel=channel,
+                        image=open(path, "rb"),
+                        verbose=verbose,
+                    )
             except Exception as e:
                 log.error(f"Invalid Argument: {e}")
         elif not SendPlot:
@@ -70,13 +100,19 @@ class Slack:
     @staticmethod
     def report_stats(client, channel, text, attachment=None, verbose=1):
         from slack_sdk.errors import SlackApiError
+
         try:
             if attachment:
                 if not os.path.isfile(attachment):
                     log.error(f"Invalid attachment path: {attachment}")
                     return
                 Plotter.slack_file_upload(
-                    name="Attachment", client=client, channel=channel, filepath=attachment, initial_comment=text, verbose=verbose
+                    name="Attachment",
+                    client=client,
+                    channel=channel,
+                    filepath=attachment,
+                    initial_comment=text,
+                    verbose=verbose,
                 )
             else:
                 client.chat_postMessage(channel=channel, text=text)
@@ -86,13 +122,39 @@ class Slack:
             log.error(f"Error posting update: {e}")
 
     @staticmethod
-    def keras_plot_history(ModelName, export, client, channel, SendPlot, training_logs, verbose=1):
-        Plotter.plot_and_upload(platform="slack", ModelName=ModelName, export=export, client=client, channel=channel, SendPlot=SendPlot, logs=training_logs, metric="loss", verbose=verbose)
-        Plotter.plot_and_upload(platform="slack", ModelName=ModelName, export=export, client=client, channel=channel, SendPlot=SendPlot, logs=training_logs, metric="acc", verbose=verbose)
+    def keras_plot_history(
+        ModelName, export, client, channel, SendPlot, training_logs, verbose=1
+    ):
+        Plotter.plot_and_upload(
+            platform="slack",
+            ModelName=ModelName,
+            export=export,
+            client=client,
+            channel=channel,
+            SendPlot=SendPlot,
+            logs=training_logs,
+            metric="loss",
+            verbose=verbose,
+        )
+        Plotter.plot_and_upload(
+            platform="slack",
+            ModelName=ModelName,
+            export=export,
+            client=client,
+            channel=channel,
+            SendPlot=SendPlot,
+            logs=training_logs,
+            metric="acc",
+            verbose=verbose,
+        )
 
     @staticmethod
-    def lightning_plot_history(ModelName, export, client, channel, SendPlot, training_logs, verbose=1):
-        Slack.keras_plot_history(ModelName, export, client, channel, SendPlot, training_logs, verbose)
+    def lightning_plot_history(
+        ModelName, export, client, channel, SendPlot, training_logs, verbose=1
+    ):
+        Slack.keras_plot_history(
+            ModelName, export, client, channel, SendPlot, training_logs, verbose
+        )
 
 
 class Telegram:
@@ -101,6 +163,7 @@ class Telegram:
     @staticmethod
     def report_stats(token, channel, text, attachment=None, verbose=1):
         import requests
+
         url = f"https://api.telegram.org/bot{token}/sendMessage"
         try:
             if attachment:
@@ -108,7 +171,14 @@ class Telegram:
                     log.error(f"Invalid attachment path: {attachment}")
                     return
                 with open(attachment, "rb") as f:
-                    Plotter.telegram_file_upload(name="Attachment", token=token, channel=channel, file=f, caption=text, verbose=verbose)
+                    Plotter.telegram_file_upload(
+                        name="Attachment",
+                        token=token,
+                        channel=channel,
+                        file=f,
+                        caption=text,
+                        verbose=verbose,
+                    )
             else:
                 requests.post(url, params={"chat_id": channel, "text": text})
                 if verbose >= 1:
@@ -117,10 +187,36 @@ class Telegram:
             log.error(f"Error posting update: {e}")
 
     @staticmethod
-    def keras_plot_history(ModelName, export, token, channel, SendPlot, training_logs, verbose=1):
-        Plotter.plot_and_upload(platform="telegram", ModelName=ModelName, export=export, client=token, channel=channel, SendPlot=SendPlot, logs=training_logs, metric="loss", verbose=verbose)
-        Plotter.plot_and_upload(platform="telegram", ModelName=ModelName, export=export, client=token, channel=channel, SendPlot=SendPlot, logs=training_logs, metric="acc", verbose=verbose)
+    def keras_plot_history(
+        ModelName, export, token, channel, SendPlot, training_logs, verbose=1
+    ):
+        Plotter.plot_and_upload(
+            platform="telegram",
+            ModelName=ModelName,
+            export=export,
+            client=token,
+            channel=channel,
+            SendPlot=SendPlot,
+            logs=training_logs,
+            metric="loss",
+            verbose=verbose,
+        )
+        Plotter.plot_and_upload(
+            platform="telegram",
+            ModelName=ModelName,
+            export=export,
+            client=token,
+            channel=channel,
+            SendPlot=SendPlot,
+            logs=training_logs,
+            metric="acc",
+            verbose=verbose,
+        )
 
     @staticmethod
-    def lightning_plot_history(ModelName, export, token, channel, SendPlot, training_logs, verbose=1):
-        Telegram.keras_plot_history(ModelName, export, token, channel, SendPlot, training_logs, verbose)
+    def lightning_plot_history(
+        ModelName, export, token, channel, SendPlot, training_logs, verbose=1
+    ):
+        Telegram.keras_plot_history(
+            ModelName, export, token, channel, SendPlot, training_logs, verbose
+        )

--- a/slackker/utils/logger.py
+++ b/slackker/utils/logger.py
@@ -1,4 +1,5 @@
 import sys
+
 from loguru import logger
 
 # Remove default handler

--- a/slackker/utils/network.py
+++ b/slackker/utils/network.py
@@ -1,7 +1,9 @@
-import os
 import asyncio
+import os
+
 import httpx
 from slack_sdk.web.async_client import AsyncWebClient
+
 from slackker.utils.logger import log
 
 
@@ -35,22 +37,29 @@ def _run_sync(coro):
 
     if loop and loop.is_running():
         import nest_asyncio
+
         nest_asyncio.apply()
         return loop.run_until_complete(coro)
     else:
         return asyncio.run(coro)
 
 
-async def check_connection(url: str, retries: int = 3, delay: float = 30, verbose: int = 2) -> bool:
+async def check_connection(
+    url: str, retries: int = 3, delay: float = 30, verbose: int = 2
+) -> bool:
     """Check if a server is reachable. Retries indefinitely if retries=0, else up to `retries` times."""
     attempt = 0
     async with _make_async_client() as client:
         while True:
             attempt += 1
             try:
-                resp = await client.head(f"https://{url}", timeout=10, follow_redirects=True)
+                resp = await client.head(
+                    f"https://{url}", timeout=10, follow_redirects=True
+                )
                 if verbose >= 2:
-                    log.debug(f"Connection to '{url}' server successful! [{_ip_mode()}]")
+                    log.debug(
+                        f"Connection to '{url}' server successful! [{_ip_mode()}]"
+                    )
                 return True
             except (httpx.RequestError, httpx.HTTPStatusError) as e:
                 if retries > 0 and attempt >= retries:
@@ -69,9 +78,13 @@ async def check_connection(url: str, retries: int = 3, delay: float = 30, verbos
                 await asyncio.sleep(delay)
 
 
-async def check_connection_quick(url: str, max_retries: int = 3, delay: float = 10, verbose: int = 1) -> bool:
+async def check_connection_quick(
+    url: str, max_retries: int = 3, delay: float = 10, verbose: int = 1
+) -> bool:
     """Quick connectivity check with limited retries (for use during training epochs)."""
-    return await check_connection(url=url, retries=max_retries, delay=delay, verbose=verbose)
+    return await check_connection(
+        url=url, retries=max_retries, delay=delay, verbose=verbose
+    )
 
 
 async def verify_slack_token(token: str, verbose: int = 2) -> bool:
@@ -79,8 +92,12 @@ async def verify_slack_token(token: str, verbose: int = 2) -> bool:
     session = None
     if os.environ.get("SLACKKER_FORCE_IPV4", "").lower() in ("1", "true"):
         import socket
+
         import aiohttp
-        session = aiohttp.ClientSession(connector=aiohttp.TCPConnector(family=socket.AF_INET))
+
+        session = aiohttp.ClientSession(
+            connector=aiohttp.TCPConnector(family=socket.AF_INET)
+        )
     try:
         if session:
             client = AsyncWebClient(token=token, session=session)
@@ -112,7 +129,9 @@ async def get_telegram_chat_id(token: str, verbose: int = 2) -> str | None:
             return chat_id
     except Exception as e:
         log.error(f"Could not connect to Telegram API: {e} [{_ip_mode()}]")
-        log.warning("Please send 'Hello' once to your bot to make it discoverable to slackker")
+        log.warning(
+            "Please send 'Hello' once to your bot to make it discoverable to slackker"
+        )
         return None
 
 
@@ -141,7 +160,9 @@ async def get_teams_device_code(
                 log.debug("Teams: Device code obtained successfully.")
             return resp.json()
     except httpx.HTTPStatusError as e:
-        log.error(f"Teams: Failed to get device code ({e.response.status_code}): {e.response.text}")
+        log.error(
+            f"Teams: Failed to get device code ({e.response.status_code}): {e.response.text}"
+        )
         return None
     except Exception as e:
         log.error(f"Teams: Failed to get device code: {e}")
@@ -192,7 +213,9 @@ async def poll_teams_device_code_token(
                 continue
             else:
                 # authorization_declined, expired_token, bad_verification_code
-                log.error(f"Teams: Authentication failed: {data.get('error_description', error)}")
+                log.error(
+                    f"Teams: Authentication failed: {data.get('error_description', error)}"
+                )
                 return None
 
 
@@ -229,7 +252,9 @@ async def refresh_teams_access_token(
             return None
     except httpx.HTTPStatusError as e:
         if verbose >= 1:
-            log.warning(f"Teams: Token refresh failed ({e.response.status_code}), re-authentication required.")
+            log.warning(
+                f"Teams: Token refresh failed ({e.response.status_code}), re-authentication required."
+            )
         return None
     except Exception as e:
         log.error(f"Teams: Token refresh error: {e}")
@@ -238,11 +263,16 @@ async def refresh_teams_access_token(
 
 # --- Sync wrappers ---
 
-def check_connection_sync(url: str, retries: int = 3, delay: float = 30, verbose: int = 2) -> bool:
+
+def check_connection_sync(
+    url: str, retries: int = 3, delay: float = 30, verbose: int = 2
+) -> bool:
     return _run_sync(check_connection(url, retries, delay, verbose))
 
 
-def check_connection_quick_sync(url: str, max_retries: int = 3, delay: float = 10, verbose: int = 1) -> bool:
+def check_connection_quick_sync(
+    url: str, max_retries: int = 3, delay: float = 10, verbose: int = 1
+) -> bool:
     return _run_sync(check_connection_quick(url, max_retries, delay, verbose))
 
 
@@ -263,10 +293,14 @@ def get_teams_device_code_sync(
 def poll_teams_device_code_token_sync(
     app_id: str, tenant_id: str, device_code: str, interval: int = 5, verbose: int = 2
 ) -> dict | None:
-    return _run_sync(poll_teams_device_code_token(app_id, tenant_id, device_code, interval, verbose))
+    return _run_sync(
+        poll_teams_device_code_token(app_id, tenant_id, device_code, interval, verbose)
+    )
 
 
 def refresh_teams_access_token_sync(
     app_id: str, tenant_id: str, refresh_token: str, scopes: list[str], verbose: int = 2
 ) -> dict | None:
-    return _run_sync(refresh_teams_access_token(app_id, tenant_id, refresh_token, scopes, verbose))
+    return _run_sync(
+        refresh_teams_access_token(app_id, tenant_id, refresh_token, scopes, verbose)
+    )

--- a/slackker/utils/network.py
+++ b/slackker/utils/network.py
@@ -19,6 +19,13 @@ def _make_async_client(**kwargs) -> httpx.AsyncClient:
     return httpx.AsyncClient(**kwargs)
 
 
+def _ip_mode() -> str:
+    """Return a short label for the active IP stack mode shown in log messages."""
+    if os.environ.get("SLACKKER_FORCE_IPV4", "").lower() in ("1", "true"):
+        return "IPv4"
+    return "IPv4/IPv6"
+
+
 def _run_sync(coro):
     """Run an async coroutine synchronously, handling already-running event loops (e.g. Jupyter)."""
     try:
@@ -43,21 +50,21 @@ async def check_connection(url: str, retries: int = 3, delay: float = 30, verbos
             try:
                 resp = await client.head(f"https://{url}", timeout=10, follow_redirects=True)
                 if verbose >= 2:
-                    log.debug(f"Connection to '{url}' server successful!")
+                    log.debug(f"Connection to '{url}' server successful! [{_ip_mode()}]")
                 return True
             except (httpx.RequestError, httpx.HTTPStatusError) as e:
                 if retries > 0 and attempt >= retries:
                     if verbose >= 1:
                         log.warning(
                             f"Connection to '{url}' server failed after {attempt} attempts. "
-                            f"Reason: {e}"
+                            f"Reason: {e} [{_ip_mode()}]"
                         )
                     return False
                 if verbose >= 1:
                     log.warning(
                         f"Connection to '{url}' server failed. "
                         f"Trying again in {delay}s.. [attempt {attempt}] "
-                        f"Reason: {e}"
+                        f"Reason: {e} [{_ip_mode()}]"
                     )
                 await asyncio.sleep(delay)
 
@@ -81,10 +88,10 @@ async def verify_slack_token(token: str, verbose: int = 2) -> bool:
             client = AsyncWebClient(token=token)
         response = await client.api_test()
         if verbose >= 2:
-            log.debug(f"Connection to Slack API successful! {response}")
+            log.debug(f"Connection to Slack API successful! [{_ip_mode()}]")
         return True
     except Exception as e:
-        log.error(f"Invalid Slack API token: {e}")
+        log.error(f"Invalid Slack API token: {e} [{_ip_mode()}]")
         return False
     finally:
         if session:
@@ -100,11 +107,11 @@ async def get_telegram_chat_id(token: str, verbose: int = 2) -> str | None:
             data = resp.json()
             chat_id = str(data["result"][0]["message"]["chat"]["id"])
             if verbose >= 2:
-                log.debug("Connection to Telegram API successful!")
+                log.debug(f"Connection to Telegram API successful! [{_ip_mode()}]")
                 log.debug(f"Found chat with 'chat_id'={chat_id}")
             return chat_id
     except Exception as e:
-        log.error(f"Could not connect to Telegram API: {e}")
+        log.error(f"Could not connect to Telegram API: {e} [{_ip_mode()}]")
         log.warning("Please send 'Hello' once to your bot to make it discoverable to slackker")
         return None
 

--- a/slackker/utils/network.py
+++ b/slackker/utils/network.py
@@ -1,7 +1,22 @@
+import os
 import asyncio
 import httpx
 from slack_sdk.web.async_client import AsyncWebClient
 from slackker.utils.logger import log
+
+
+def _make_async_client(**kwargs) -> httpx.AsyncClient:
+    """Create an httpx.AsyncClient, optionally forced to IPv4.
+
+    Set ``SLACKKER_FORCE_IPV4=1`` in the environment to bind all outbound
+    connections to an IPv4 socket (AF_INET). This is useful in Docker
+    containers where the internal DNS resolver returns IPv6 addresses first
+    but the container has no IPv6 outbound route configured.
+    """
+    if os.environ.get("SLACKKER_FORCE_IPV4", "").lower() in ("1", "true"):
+        transport = httpx.AsyncHTTPTransport(local_address="0.0.0.0", retries=3)
+        return httpx.AsyncClient(transport=transport, **kwargs)
+    return httpx.AsyncClient(**kwargs)
 
 
 def _run_sync(coro):
@@ -22,7 +37,7 @@ def _run_sync(coro):
 async def check_connection(url: str, retries: int = 3, delay: float = 30, verbose: int = 2) -> bool:
     """Check if a server is reachable. Retries indefinitely if retries=0, else up to `retries` times."""
     attempt = 0
-    async with httpx.AsyncClient() as client:
+    async with _make_async_client() as client:
         while True:
             attempt += 1
             try:
@@ -54,8 +69,16 @@ async def check_connection_quick(url: str, max_retries: int = 3, delay: float = 
 
 async def verify_slack_token(token: str, verbose: int = 2) -> bool:
     """Verify a Slack API token by calling api.test."""
+    session = None
+    if os.environ.get("SLACKKER_FORCE_IPV4", "").lower() in ("1", "true"):
+        import socket
+        import aiohttp
+        session = aiohttp.ClientSession(connector=aiohttp.TCPConnector(family=socket.AF_INET))
     try:
-        client = AsyncWebClient(token=token)
+        if session:
+            client = AsyncWebClient(token=token, session=session)
+        else:
+            client = AsyncWebClient(token=token)
         response = await client.api_test()
         if verbose >= 2:
             log.debug(f"Connection to Slack API successful! {response}")
@@ -63,13 +86,16 @@ async def verify_slack_token(token: str, verbose: int = 2) -> bool:
     except Exception as e:
         log.error(f"Invalid Slack API token: {e}")
         return False
+    finally:
+        if session:
+            await session.close()
 
 
 async def get_telegram_chat_id(token: str, verbose: int = 2) -> str | None:
     """Retrieve the chat_id from the first message sent to the Telegram bot."""
     url = f"https://api.telegram.org/bot{token}/getUpdates"
     try:
-        async with httpx.AsyncClient() as client:
+        async with _make_async_client() as client:
             resp = await client.get(url)
             data = resp.json()
             chat_id = str(data["result"][0]["message"]["chat"]["id"])
@@ -101,7 +127,7 @@ async def get_teams_device_code(
         "scope": " ".join(scopes),
     }
     try:
-        async with httpx.AsyncClient() as client:
+        async with _make_async_client() as client:
             resp = await client.post(url, data=payload, timeout=10)
             resp.raise_for_status()
             if verbose >= 2:
@@ -136,7 +162,7 @@ async def poll_teams_device_code_token(
         "device_code": device_code,
     }
     poll_interval = max(interval, 5)
-    async with httpx.AsyncClient() as client:
+    async with _make_async_client() as client:
         while True:
             await asyncio.sleep(poll_interval)
             try:
@@ -184,7 +210,7 @@ async def refresh_teams_access_token(
         "scope": " ".join(scopes),
     }
     try:
-        async with httpx.AsyncClient() as client:
+        async with _make_async_client() as client:
             resp = await client.post(url, data=payload, timeout=10)
             resp.raise_for_status()
             data = resp.json()

--- a/slackker/utils/plotting.py
+++ b/slackker/utils/plotting.py
@@ -1,6 +1,5 @@
-import os
-import itertools
 import matplotlib.pyplot as plt
+
 from slackker.utils.logger import log
 
 
@@ -14,7 +13,18 @@ def generate_plot(model_name: str, export: str, logs: dict, metric: str) -> str 
         first_key = next(iter(logs))
         epochs = range(len(logs[first_key]))
 
-        color_cycle = ['b-', 'g-', 'r-', 'c-', 'm-', 'y-', 'k-', 'orange', 'darkviolet', 'fuchsia']
+        color_cycle = [
+            "b-",
+            "g-",
+            "r-",
+            "c-",
+            "m-",
+            "y-",
+            "k-",
+            "orange",
+            "darkviolet",
+            "fuchsia",
+        ]
         colors_iter = iter(color_cycle)
 
         path = f"{model_name}_{metric}.{export}"
@@ -22,7 +32,13 @@ def generate_plot(model_name: str, export: str, logs: dict, metric: str) -> str 
         plt.figure(figsize=(15, 8))
         for key, values in logs.items():
             if metric in key.lower():
-                plt.plot(epochs, values, next(colors_iter), lw=2.5, label=f"{key}: {values[-1]:.4f}")
+                plt.plot(
+                    epochs,
+                    values,
+                    next(colors_iter),
+                    lw=2.5,
+                    label=f"{key}: {values[-1]:.4f}",
+                )
         plt.title(f"{model_name}_{metric}_Graph", fontsize=20)
         plt.xlabel("Epochs", fontsize=15)
         plt.ylabel(metric, fontsize=15)
@@ -37,7 +53,9 @@ def generate_plot(model_name: str, export: str, logs: dict, metric: str) -> str 
         return None
 
 
-def generate_and_get_plots(model_name: str, export: str, training_logs: dict, metrics: list[str] | None = None) -> list[str]:
+def generate_and_get_plots(
+    model_name: str, export: str, training_logs: dict, metrics: list[str] | None = None
+) -> list[str]:
     """Generate plots for specified metrics (default: loss + acc). Returns list of file paths."""
     if metrics is None:
         metrics = ["loss", "acc"]

--- a/uv.lock
+++ b/uv.lock
@@ -2317,7 +2317,7 @@ wheels = [
 
 [[package]]
 name = "slackker"
-version = "1.4.1"
+version = "1.4.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/uv.lock
+++ b/uv.lock
@@ -1431,6 +1431,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nest-asyncio"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/83/f8/51569ac65d696c8ecbee95938f89d4abf00f47d58d48f6fbabfe8f0baefe/nest_asyncio-1.6.0.tar.gz", hash = "sha256:6f172d5449aca15afd6c646851f4e31e02c598d553a667e38cafa997cfec55fe", size = 7418, upload-time = "2024-01-21T14:25:19.227Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl", hash = "sha256:87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c", size = 5195, upload-time = "2024-01-21T14:25:17.223Z" },
+]
+
+[[package]]
 name = "networkx"
 version = "3.6.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2315,6 +2324,7 @@ dependencies = [
     { name = "httpx" },
     { name = "loguru" },
     { name = "matplotlib" },
+    { name = "nest-asyncio" },
     { name = "numpy" },
     { name = "requests" },
     { name = "slack-sdk" },
@@ -2339,6 +2349,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "loguru", specifier = ">=0.7.0" },
     { name = "matplotlib", specifier = ">=3.7.5" },
+    { name = "nest-asyncio", specifier = ">=1.6.0" },
     { name = "numpy", specifier = ">=1.24.4" },
     { name = "requests", specifier = ">=2.31.0" },
     { name = "slack-sdk", specifier = ">=3.39.0" },

--- a/website/index.html
+++ b/website/index.html
@@ -579,7 +579,7 @@ trainer.fit(model, train_loader, val_loader)</code></pre>
     <div class="footer-bar">
       <div class="footer-status">
         <span class="footer-pulse"></span>
-        <span>slackker v1.4.1</span>
+        <span>slackker v1.4.4</span>
       </div>
       <div class="footer-links">
         <a href="https://github.com/siddheshgunjal/slackker" target="_blank" rel="noreferrer">GitHub</a>


### PR DESCRIPTION
## Summary
This PR focuses on adding configuration support for IPv4-only networking (useful for Docker containers or restricted network environments).and codebase refactoring, improving code quality through consistent formatting

## Key Changes

### 🔧 **IPv6/IPv4 Configuration** (New Feature)
- **`slackker/utils/network.py`**: 
  - Added `_make_async_client()` helper to create `httpx.AsyncClient` instances with optional IPv4 forcing
  - Added `_ip_mode()` utility to detect current IP stack mode
  - Supports `SLACKKER_FORCE_IPV4=1` environment variable to bind all outbound connections to IPv4 sockets
  - IPv4 mode is automatically detected and displayed in log messages (e.g., `[IPv4]` or `[IPv4/IPv6]`)

### 🛠 **Network Stack Improvements**
- **`slackker/core/teams.py`**: Replaced raw `httpx.AsyncClient()` with `_make_async_client()` for consistent IPv4 handling
- **`slackker/core/telegram.py`**: Same IPv4 client consistency applied
- **`slackker/utils/network.py`**: 
  - Updated `check_connection()` and `check_connection_quick()` to use `_make_async_client()`
  - Enhanced `verify_slack_token()` to respect IPv4 forcing when using `aiohttp`
  - Updated error logs to include IP mode context

### 🧹 **Code Quality & Formatting**
- Standardized all `httpx.AsyncClient` calls to use `_make_async_client()`
- Reformatted tuple literals to multiline for better readability (e.g., `SUPPORTED_FORMATS`, function signatures)
- Fixed import ordering across all modules
- Converted single quotes to double quotes in `slackker/__init__.py`
- Fixed tab-to-space conversion in `slackker/utils/ccolors.py`
- Added trailing newline to files ending without one

## Technical Details
- **Added dependency**: `nest-asyncio>=1.6.0` (enables `nest_asyncio.apply()` for running async code in Jupyter/notebook environments)
- **Backward compatible**: All deprecated aliases (`*Update`, `Slack`, `Telegram` legacy classes) remain intact