### PR TITLE
Unify Channel Identifier as `channel_id` Across Clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ from slackker.core import SlackClient, TelegramClient, TeamsClient, DiscordClien
 # Slack
 client = SlackClient(
     token="xoxb-123234234235-123234234235-adedce74748c3844747aed",
-    channel="C04AAB77ABC",
+    channel_id="C04AAB77ABC",
     verbose=0,
 )
 
@@ -85,18 +85,18 @@ client = TelegramClient(
     verbose=0,
 )
 
+# Discord
+client = DiscordClient(
+    token="your_bot_token_here",
+    channel_id="123456789012345678",
+    verbose=0,
+)
+
 # Microsoft Teams
 client = TeamsClient(
     app_id="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
     tenant_id="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
     chat_id="19:xxxxxxxxxxxxxxxxxxxxxx_xxxxxxxxxxxxxxxxxxxxxx@thread.v2",
-    verbose=0,
-)
-
-# Discord
-client = DiscordClient(
-    token="your_bot_token_here",
-    channel_id="123456789012345678",
     verbose=0,
 )
 ```
@@ -111,8 +111,7 @@ client = DiscordClient(
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `token` | `str` | _required_ | Slack app / Telegram bot / Discord bot token |
-| `channel` | `str` | _required (Slack only)_ | Slack channel ID |
-| `channel_id` | `str` | _required (Discord only)_ | Discord channel ID |
+| `channel_id` | `str` | _required (Slack & Discord only)_ | Slack or Discord channel ID |
 | `chat_id` | `str` | `None` _(Telegram only)_ | Telegram chat ID — auto-discovered if omitted |
 | `verbose` | `int` | `0` | `0` = silent, `1` = info, `2` = debug |
 
@@ -372,7 +371,7 @@ from slackker.callbacks.basic import SlackUpdate   # or TelegramUpdate
 # Slack
 slackker = SlackUpdate(
     token="xoxb-123234234235-123234234235-adedce74748c3844747aed",
-    channel="C04AAB77ABC",
+    channel_id="C04AAB77ABC",
 )
 
 # Telegram
@@ -391,7 +390,7 @@ from slackker.callbacks.keras import SlackUpdate   # or TelegramUpdate
 
 slackker = SlackUpdate(
     token="xoxb-123234234235-123234234235-adedce74748c3844747aed",
-    channel="C04AAB77ABC",
+    channel_id="C04AAB77ABC",
     ModelName="Keras_NN",
     export="png",
     SendPlot=True,
@@ -406,7 +405,7 @@ from slackker.callbacks.lightning import SlackUpdate   # or TelegramUpdate
 
 slackker = SlackUpdate(
     token="xoxb-123234234235-123234234235-adedce74748c3844747aed",
-    channel="C04AAB77ABC",
+    channel_id="C04AAB77ABC",
     ModelName="Lightning NN",
     TrackLogs=["train_loss", "train_acc", "val_loss", "val_acc"],
     monitor="val_loss",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "slackker"
-version = "1.4.8"
+version = "1.4.9"
 description = "Python package for monitoring your pipeline & Model training status in real-time on Slack, Telegram and Microsoft Teams."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/slackker/__init__.py
+++ b/slackker/__init__.py
@@ -11,7 +11,7 @@ from slackker.listener import CommandHandler, MessagePoller
 
 __author__ = "Siddhesh Gunjal"
 __email__ = "siddhu19@live.com"
-__version__ = "1.4.8"
+__version__ = "1.4.9"
 
 # module level doc-string
 __doc__ = """

--- a/slackker/callbacks/basic.py
+++ b/slackker/callbacks/basic.py
@@ -33,9 +33,9 @@ class Update(SimpleCallback):
 class SlackUpdate(SimpleCallback):
     """Deprecated: Use SimpleCallback(SlackClient(...)) instead."""
 
-    def __init__(self, token, channel, verbose=0):
+    def __init__(self, token, channel_id, verbose=0):
         warnings.warn(
-            "SlackUpdate is deprecated. Use SimpleCallback(SlackClient(token, channel)) instead.",
+            "SlackUpdate is deprecated. Use SimpleCallback(SlackClient(token, channel_id)) instead.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -43,7 +43,7 @@ class SlackUpdate(SimpleCallback):
             log.error("Please enter a valid Slack API Token.")
             return
 
-        client = SlackClient(token=token, channel=channel, verbose=verbose)
+        client = SlackClient(token=token, channel_id=channel_id, verbose=verbose)
         connected = _sync(client.connect())
         if connected:
             super().__init__(client)

--- a/slackker/callbacks/keras.py
+++ b/slackker/callbacks/keras.py
@@ -126,10 +126,10 @@ class SlackUpdate(KerasCallback):
     """Deprecated: Use KerasCallback(SlackClient(...), ...) instead."""
 
     def __init__(
-        self, token, channel, ModelName, export="png", SendPlot=False, verbose=0
+        self, token, channel_id, ModelName, export="png", SendPlot=False, verbose=0
     ):
         warnings.warn(
-            "SlackUpdate is deprecated. Use KerasCallback(SlackClient(token, channel), model_name) instead.",
+            "SlackUpdate is deprecated. Use KerasCallback(SlackClient(token, channel_id), model_name) instead.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -137,7 +137,7 @@ class SlackUpdate(KerasCallback):
             log.error("Please enter a valid Slack API Token.")
             return
 
-        client = SlackClient(token=token, channel=channel, verbose=verbose)
+        client = SlackClient(token=token, channel_id=channel_id, verbose=verbose)
         connected = _run_sync(client.connect())
         if not connected:
             log.error("Failed to connect to Slack.")
@@ -152,7 +152,7 @@ class SlackUpdate(KerasCallback):
         self.SendPlot = SendPlot
         self.verbose = verbose
         self._sdk_client = client._client
-        self.channel = channel
+        self.channel_id = channel_id
 
 
 class TelegramUpdate(KerasCallback):

--- a/slackker/callbacks/lightning.py
+++ b/slackker/callbacks/lightning.py
@@ -132,7 +132,7 @@ class SlackUpdate(LightningCallback):
     def __init__(
         self,
         token,
-        channel,
+        channel_id,
         ModelName,
         TrackLogs=None,
         monitor=None,
@@ -141,7 +141,7 @@ class SlackUpdate(LightningCallback):
         verbose=0,
     ):
         warnings.warn(
-            "SlackUpdate is deprecated. Use LightningCallback(SlackClient(token, channel), ...) instead.",
+            "SlackUpdate is deprecated. Use LightningCallback(SlackClient(token, channel_id), ...) instead.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -149,7 +149,7 @@ class SlackUpdate(LightningCallback):
             log.error("Please enter a valid Slack API Token.")
             return
 
-        client = SlackClient(token=token, channel=channel, verbose=verbose)
+        client = SlackClient(token=token, channel_id=channel_id, verbose=verbose)
         connected = _run_sync(client.connect())
         if not connected:
             log.error("Failed to connect to Slack.")
@@ -170,7 +170,7 @@ class SlackUpdate(LightningCallback):
         self.SendPlot = SendPlot
         self.verbose = verbose
         self._sdk_client = client._client
-        self.channel = channel
+        self.channel_id = channel_id
 
 
 class TelegramUpdate(LightningCallback):

--- a/slackker/core/slack.py
+++ b/slackker/core/slack.py
@@ -12,12 +12,12 @@ from slackker.utils.logger import log
 class SlackClient(BaseClient):
     """Slack client backend using the async Slack SDK."""
 
-    def __init__(self, token: str, channel: str, verbose: int = 0):
+    def __init__(self, token: str, channel_id: str, verbose: int = 0):
         super().__init__(verbose=verbose)
         if not token:
             raise ValueError("Slack API token is required.")
         self._token = token
-        self._channel = channel
+        self._channel_id = channel_id
         self._client = AsyncWebClient(token=token)
         self._connected = False
 
@@ -26,8 +26,8 @@ class SlackClient(BaseClient):
         return "slack"
 
     @property
-    def channel(self) -> str:
-        return self._channel
+    def channel_id(self) -> str:
+        return self._channel_id
 
     @property
     def is_connected(self) -> bool:
@@ -48,9 +48,9 @@ class SlackClient(BaseClient):
 
     async def send_message(self, text: str) -> None:
         try:
-            await self._client.chat_postMessage(channel=self._channel, text=text)
+            await self._client.chat_postMessage(channel=self._channel_id, text=text)
             if self._verbose >= 1:
-                log.info(f"Posted update on {self._channel} channel")
+                log.info(f"Posted update on {self._channel_id} channel")
         except SlackApiError as e:
             log.error(f"Error posting update: {e}")
 
@@ -61,12 +61,12 @@ class SlackClient(BaseClient):
                 return
             initial_comment = comment or "Attachment 📎"
             await self._client.files_upload_v2(
-                channel=self._channel,
+                channel=self._channel_id,
                 file=filepath,
                 initial_comment=initial_comment,
             )
             if self._verbose >= 1:
-                log.debug(f"Uploaded attachment on {self._channel} channel")
+                log.debug(f"Uploaded attachment on {self._channel_id} channel")
         except SlackApiError as e:
             log.error(f"Error uploading attachment: {e}")
 
@@ -90,17 +90,18 @@ class SlackClient(BaseClient):
         try:
             if thread_id:
                 resp = await self._client.conversations_replies(
-                    channel=self._channel,
+                    channel=self._channel_id,
                     ts=thread_id,
                     oldest=since,
-                    limit=limit + 1,  # +1 because the parent is always the first element
+                    limit=limit
+                    + 1,  # +1 because the parent is always the first element
                 )
                 # conversations.replies is already chronological (oldest first);
                 # skip index 0 which is always the parent message itself.
                 raw_messages = (resp.get("messages") or [])[1:]
             else:
                 resp = await self._client.conversations_history(
-                    channel=self._channel,
+                    channel=self._channel_id,
                     oldest=since,
                     limit=limit,
                 )

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -3,15 +3,17 @@ Comprehensive tests for slackker.callbacks.simple and slackker.callbacks.basic m
 Tests cover SimpleCallback and backward-compatible Update/SlackUpdate/TelegramUpdate shims.
 """
 
-import pytest
 import warnings
 from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from slackker.callbacks.basic import SlackUpdate, TelegramUpdate, Update
 from slackker.callbacks.simple import SimpleCallback
-from slackker.callbacks.basic import Update, SlackUpdate, TelegramUpdate
 from slackker.core.client import BaseClient
 
-
 # ── Fixtures ──────────────────────────────────────────────────
+
 
 class MockClient(BaseClient):
     """Concrete test client that records calls."""
@@ -59,6 +61,7 @@ def _make_update(verbose=0):
 
 # ── SimpleCallback tests ──────────────────────────────────────
 
+
 class TestSimpleCallbackNotifier:
     """Test SimpleCallback.notifier decorator."""
 
@@ -101,6 +104,7 @@ class TestSimpleCallbackNotifier:
 
     def test_notifier_execution_time(self):
         import time
+
         cb, client = _make_callback()
 
         @cb.notifier
@@ -227,6 +231,7 @@ class TestAsyncNotify:
 
 # ── Deprecated Update alias test ─────────────────────────────
 
+
 class TestUpdateDeprecation:
     """Ensure Update emits DeprecationWarning and still works."""
 
@@ -250,6 +255,7 @@ class TestUpdateDeprecation:
 
 # ── Backward-compat shim tests ───────────────────────────────
 
+
 class TestSlackUpdateShim:
     """Test backward-compatible SlackUpdate."""
 
@@ -261,7 +267,7 @@ class TestSlackUpdateShim:
 
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            obj = SlackUpdate(token="test", channel="C123", verbose=0)
+            obj = SlackUpdate(token="test", channel_id="C123", verbose=0)
             assert len(w) == 1
             assert issubclass(w[0].category, DeprecationWarning)
             assert "SlackUpdate is deprecated" in str(w[0].message)
@@ -274,7 +280,7 @@ class TestSlackUpdateShim:
 
         with warnings.catch_warnings(record=True):
             warnings.simplefilter("always")
-            obj = SlackUpdate(token="test", channel="C123", verbose=0)
+            obj = SlackUpdate(token="test", channel_id="C123", verbose=0)
 
         assert hasattr(obj, "client")
         assert obj.client is mock_client
@@ -282,7 +288,7 @@ class TestSlackUpdateShim:
     def test_init_no_token(self):
         with warnings.catch_warnings(record=True):
             warnings.simplefilter("always")
-            obj = SlackUpdate(token=None, channel="C123")
+            obj = SlackUpdate(token=None, channel_id="C123")
         assert not hasattr(obj, "client")
 
 
@@ -331,7 +337,7 @@ class TestShimWorkflows:
 
         with warnings.catch_warnings(record=True):
             warnings.simplefilter("always")
-            obj = SlackUpdate(token="xoxb-test", channel="C123", verbose=0)
+            obj = SlackUpdate(token="xoxb-test", channel_id="C123", verbose=0)
 
         @obj.notifier
         def compute(x, y):
@@ -365,6 +371,7 @@ class TestShimWorkflows:
 
 # ── Auto-connect tests ───────────────────────────────────────
 
+
 class DisconnectedMockClient(MockClient):
     """MockClient that starts disconnected and records connect() calls."""
 
@@ -394,7 +401,7 @@ class TestAutoConnect:
         assert client.is_connected
 
     def test_skips_connect_when_already_connected(self):
-        client = MockClient()          # is_connected always True
+        client = MockClient()  # is_connected always True
         SimpleCallback(client)
         # MockClient has no connect_calls attr — just ensure no AttributeError
         assert client.is_connected
@@ -411,7 +418,7 @@ class TestShimConnectFails:
 
         with warnings.catch_warnings(record=True):
             warnings.simplefilter("always")
-            obj = SlackUpdate(token="xoxb-test", channel="C123")
+            obj = SlackUpdate(token="xoxb-test", channel_id="C123")
 
         assert not hasattr(obj, "client")
 
@@ -433,6 +440,7 @@ if __name__ == "__main__":
 
 # ── SimpleCallback.ask / async_ask / stop / async_stop tests ─────────────────
 
+
 class MockPoller:
     """Minimal MessagePoller stand-in that returns a preset reply."""
 
@@ -445,9 +453,14 @@ class MockPoller:
 
 def _make_reply(text="yes", sender="human"):
     from slackker.core.models import IncomingMessage
+
     return IncomingMessage(
-        text=text, sender=sender, sender_id="u1",
-        timestamp="1", platform="mock", is_bot=False,
+        text=text,
+        sender=sender,
+        sender_id="u1",
+        timestamp="1",
+        platform="mock",
+        is_bot=False,
     )
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -35,12 +35,12 @@ class TestSlackClient:
 
     def test_init_requires_token(self):
         with pytest.raises(ValueError, match="Slack API token is required"):
-            SlackClient(token="", channel="C123")
+            SlackClient(token="", channel_id="C123")
 
     def test_init_stores_attributes(self):
-        client = SlackClient(token="xoxb-test", channel="C123", verbose=2)
+        client = SlackClient(token="xoxb-test", channel_id="C123", verbose=2)
         assert client.platform == "slack"
-        assert client.channel == "C123"
+        assert client.channel_id == "C123"
         assert client.verbose == 2
 
     @pytest.mark.asyncio
@@ -55,7 +55,7 @@ class TestSlackClient:
         return_value=True,
     )
     async def test_connect_success(self, mock_verify, mock_check):
-        client = SlackClient(token="xoxb-test", channel="C123")
+        client = SlackClient(token="xoxb-test", channel_id="C123")
         result = await client.connect()
         assert result is True
         mock_check.assert_awaited_once()
@@ -73,7 +73,7 @@ class TestSlackClient:
         return_value=True,
     )
     async def test_connect_no_internet(self, mock_verify, mock_check):
-        client = SlackClient(token="xoxb-test", channel="C123")
+        client = SlackClient(token="xoxb-test", channel_id="C123")
         result = await client.connect()
         assert result is False
 
@@ -89,13 +89,13 @@ class TestSlackClient:
         return_value=False,
     )
     async def test_connect_invalid_token(self, mock_verify, mock_check):
-        client = SlackClient(token="xoxb-bad", channel="C123")
+        client = SlackClient(token="xoxb-bad", channel_id="C123")
         result = await client.connect()
         assert result is False
 
     @pytest.mark.asyncio
     async def test_send_message(self):
-        client = SlackClient(token="xoxb-test", channel="C123", verbose=0)
+        client = SlackClient(token="xoxb-test", channel_id="C123", verbose=0)
         client._client = AsyncMock()
         client._client.chat_postMessage = AsyncMock()
 
@@ -106,14 +106,14 @@ class TestSlackClient:
 
     @pytest.mark.asyncio
     async def test_upload_file_invalid_path(self):
-        client = SlackClient(token="xoxb-test", channel="C123", verbose=0)
+        client = SlackClient(token="xoxb-test", channel_id="C123", verbose=0)
         client._client = AsyncMock()
         # Should not raise, just log an error
         await client.upload_file("/nonexistent/file.txt")
         client._client.files_upload_v2.assert_not_awaited()
 
     def test_send_message_sync(self):
-        client = SlackClient(token="xoxb-test", channel="C123", verbose=0)
+        client = SlackClient(token="xoxb-test", channel_id="C123", verbose=0)
         client._client = MagicMock()
         # Mock the async method to return a coroutine
         client.send_message = AsyncMock()
@@ -945,7 +945,7 @@ class TestSlackClientCoverage:
     """Tests for lines not covered by TestSlackClient."""
 
     def test_is_connected_initially_false(self):
-        client = SlackClient(token="xoxb-test", channel="C123")
+        client = SlackClient(token="xoxb-test", channel_id="C123")
         assert client.is_connected is False
 
     @pytest.mark.asyncio
@@ -960,17 +960,17 @@ class TestSlackClientCoverage:
         return_value=True,
     )
     async def test_is_connected_true_after_connect(self, mock_verify, mock_check):
-        client = SlackClient(token="xoxb-test", channel="C123")
+        client = SlackClient(token="xoxb-test", channel_id="C123")
         await client.connect()
         assert client.is_connected is True
 
     def test_connectivity_url(self):
-        client = SlackClient(token="xoxb-test", channel="C123")
+        client = SlackClient(token="xoxb-test", channel_id="C123")
         assert client.connectivity_url == "api.slack.com"
 
     @pytest.mark.asyncio
     async def test_send_message_verbose_log(self):
-        client = SlackClient(token="xoxb-test", channel="C123", verbose=1)
+        client = SlackClient(token="xoxb-test", channel_id="C123", verbose=1)
         client._client = AsyncMock()
         client._client.chat_postMessage = AsyncMock()
 
@@ -981,7 +981,7 @@ class TestSlackClientCoverage:
     async def test_send_message_slack_api_error(self):
         from slack_sdk.errors import SlackApiError
 
-        client = SlackClient(token="xoxb-test", channel="C123")
+        client = SlackClient(token="xoxb-test", channel_id="C123")
         client._client = AsyncMock()
         client._client.chat_postMessage = AsyncMock(
             side_effect=SlackApiError("error", {"error": "channel_not_found"})
@@ -995,7 +995,7 @@ class TestSlackClientCoverage:
         file_path = tmp_path / "report.txt"
         file_path.write_text("results")
 
-        client = SlackClient(token="xoxb-test", channel="C123", verbose=1)
+        client = SlackClient(token="xoxb-test", channel_id="C123", verbose=1)
         client._client = AsyncMock()
         client._client.files_upload_v2 = AsyncMock()
 
@@ -1013,7 +1013,7 @@ class TestSlackClientCoverage:
         file_path = tmp_path / "f.txt"
         file_path.write_text("x")
 
-        client = SlackClient(token="xoxb-test", channel="C123")
+        client = SlackClient(token="xoxb-test", channel_id="C123")
         client._client = AsyncMock()
         client._client.files_upload_v2 = AsyncMock(
             side_effect=SlackApiError("upload error", {"error": "not_authed"})
@@ -1027,7 +1027,7 @@ class TestSlackClientCoverage:
         file_path = tmp_path / "f.txt"
         file_path.write_text("x")
 
-        client = SlackClient(token="xoxb-test", channel="C123")
+        client = SlackClient(token="xoxb-test", channel_id="C123")
         client._client = AsyncMock()
         client._client.files_upload_v2 = AsyncMock()
 
@@ -1040,7 +1040,7 @@ class TestSlackClientCoverage:
         file_path = tmp_path / "plot.png"
         file_path.write_text("binary")
 
-        client = SlackClient(token="xoxb-test", channel="C123")
+        client = SlackClient(token="xoxb-test", channel_id="C123")
         client.upload_file = AsyncMock()
 
         await client.upload_image(str(file_path), comment="My plot")
@@ -1048,7 +1048,7 @@ class TestSlackClientCoverage:
 
     @pytest.mark.asyncio
     async def test_close_does_not_raise(self):
-        client = SlackClient(token="xoxb-test", channel="C123")
+        client = SlackClient(token="xoxb-test", channel_id="C123")
         await client.close()  # Should be a no-op without raising
 
 

--- a/tests/test_keras.py
+++ b/tests/test_keras.py
@@ -3,15 +3,17 @@ Comprehensive tests for slackker.callbacks.keras module.
 Tests cover the new unified KerasCallback class and backward-compatible shims.
 """
 
-import pytest
 import warnings
-import numpy as np
 from unittest.mock import AsyncMock, MagicMock, patch
+
+import numpy as np
+import pytest
+
 from slackker.callbacks.keras import KerasCallback, SlackUpdate, TelegramUpdate
 from slackker.core.client import BaseClient
 
-
 # ── Fixtures ──────────────────────────────────────────────────
+
 
 class MockClient(BaseClient):
     """Concrete test client that records calls."""
@@ -58,6 +60,7 @@ def _make_callback(platform="slack", verbose=0, send_plot=False, export="png"):
 
 # ── KerasCallback initialization ──────────────────────────────
 
+
 class TestKerasCallbackInit:
     def test_init_stores_attributes(self):
         cb, _ = _make_callback()
@@ -76,6 +79,7 @@ class TestKerasCallbackInit:
 
 # ── on_train_begin ────────────────────────────────────────────
 
+
 class TestOnTrainBegin:
     def test_posts_training_start(self):
         cb, client = _make_callback()
@@ -87,8 +91,13 @@ class TestOnTrainBegin:
 
 # ── on_epoch_end ──────────────────────────────────────────────
 
+
 class TestOnEpochEnd:
-    @patch("slackker.callbacks.keras.network.check_connection_quick", new_callable=AsyncMock, return_value=True)
+    @patch(
+        "slackker.callbacks.keras.network.check_connection_quick",
+        new_callable=AsyncMock,
+        return_value=True,
+    )
     def test_tracks_metrics_and_reports(self, mock_check):
         cb, client = _make_callback()
         logs = {"accuracy": 0.85, "loss": 0.45, "val_accuracy": 0.80, "val_loss": 0.50}
@@ -100,7 +109,11 @@ class TestOnEpochEnd:
         assert len(client.messages) == 1
         assert "Epoch: 0" in client.messages[0]
 
-    @patch("slackker.callbacks.keras.network.check_connection_quick", new_callable=AsyncMock, return_value=False)
+    @patch(
+        "slackker.callbacks.keras.network.check_connection_quick",
+        new_callable=AsyncMock,
+        return_value=False,
+    )
     def test_skips_report_without_internet(self, mock_check):
         cb, client = _make_callback()
         logs = {"accuracy": 0.85, "loss": 0.45, "val_accuracy": 0.80, "val_loss": 0.50}
@@ -110,7 +123,11 @@ class TestOnEpochEnd:
         assert len(cb.train_loss) == 1
         assert len(client.messages) == 0
 
-    @patch("slackker.callbacks.keras.network.check_connection_quick", new_callable=AsyncMock, return_value=True)
+    @patch(
+        "slackker.callbacks.keras.network.check_connection_quick",
+        new_callable=AsyncMock,
+        return_value=True,
+    )
     def test_multiple_epochs(self, mock_check):
         cb, client = _make_callback()
         epochs_logs = [
@@ -129,6 +146,7 @@ class TestOnEpochEnd:
 
 # ── on_train_end ──────────────────────────────────────────────
 
+
 class TestOnTrainEnd:
     def test_reports_best_epoch(self):
         cb, client = _make_callback()
@@ -143,7 +161,10 @@ class TestOnTrainEnd:
         found_best = any("Best epoch was 2" in m for m in client.messages)
         assert found_best
 
-    @patch("slackker.callbacks.keras.plotting.generate_and_get_plots", return_value=["/tmp/loss.png", "/tmp/acc.png"])
+    @patch(
+        "slackker.callbacks.keras.plotting.generate_and_get_plots",
+        return_value=["/tmp/loss.png", "/tmp/acc.png"],
+    )
     def test_uploads_plots_when_enabled(self, mock_plots):
         cb, client = _make_callback(send_plot=True)
         cb.train_loss = [0.6, 0.4]
@@ -167,8 +188,13 @@ class TestOnTrainEnd:
 
 # ── Log ordering ──────────────────────────────────────────────
 
+
 class TestLogOrdering:
-    @patch("slackker.callbacks.keras.network.check_connection_quick", new_callable=AsyncMock, return_value=True)
+    @patch(
+        "slackker.callbacks.keras.network.check_connection_quick",
+        new_callable=AsyncMock,
+        return_value=True,
+    )
     def test_logs_stored_in_order(self, mock_check):
         cb, _ = _make_callback()
         for i in range(3):
@@ -188,9 +214,17 @@ class TestLogOrdering:
 
 # ── Complete workflow ─────────────────────────────────────────
 
+
 class TestCompleteWorkflow:
-    @patch("slackker.callbacks.keras.network.check_connection_quick", new_callable=AsyncMock, return_value=True)
-    @patch("slackker.callbacks.keras.plotting.generate_and_get_plots", return_value=["/tmp/loss.png"])
+    @patch(
+        "slackker.callbacks.keras.network.check_connection_quick",
+        new_callable=AsyncMock,
+        return_value=True,
+    )
+    @patch(
+        "slackker.callbacks.keras.plotting.generate_and_get_plots",
+        return_value=["/tmp/loss.png"],
+    )
     def test_full_training(self, mock_plots, mock_check):
         cb, client = _make_callback(send_plot=True)
 
@@ -211,6 +245,7 @@ class TestCompleteWorkflow:
 
 # ── Backward-compat shim tests ───────────────────────────────
 
+
 class TestSlackUpdateShim:
     @patch("slackker.callbacks.keras.SlackClient")
     def test_init_deprecation_warning(self, mock_cls):
@@ -221,7 +256,7 @@ class TestSlackUpdateShim:
 
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            cb = SlackUpdate(token="xoxb-test", channel="C123", ModelName="M")
+            cb = SlackUpdate(token="xoxb-test", channel_id="C123", ModelName="M")
             assert any(issubclass(x.category, DeprecationWarning) for x in w)
 
     @patch("slackker.callbacks.keras.SlackClient")
@@ -233,7 +268,13 @@ class TestSlackUpdateShim:
 
         with warnings.catch_warnings(record=True):
             warnings.simplefilter("always")
-            cb = SlackUpdate(token="xoxb-test", channel="C123", ModelName="M", SendPlot=True, verbose=2)
+            cb = SlackUpdate(
+                token="xoxb-test",
+                channel_id="C123",
+                ModelName="M",
+                SendPlot=True,
+                verbose=2,
+            )
 
         assert cb.ModelName == "M"
         assert cb.SendPlot is True
@@ -242,7 +283,7 @@ class TestSlackUpdateShim:
     def test_no_token(self):
         with warnings.catch_warnings(record=True):
             warnings.simplefilter("always")
-            cb = SlackUpdate(token=None, channel="C123", ModelName="M")
+            cb = SlackUpdate(token=None, channel_id="C123", ModelName="M")
         assert not hasattr(cb, "client")
 
 
@@ -269,7 +310,11 @@ class TestTelegramUpdateShim:
 class TestKerasCallbackMessageFormatting:
     """Test message formatting in Keras callbacks using MockClient."""
 
-    @patch("slackker.callbacks.keras.network.check_connection_quick", new_callable=AsyncMock, return_value=True)
+    @patch(
+        "slackker.callbacks.keras.network.check_connection_quick",
+        new_callable=AsyncMock,
+        return_value=True,
+    )
     def test_epoch_message_format(self, mock_check):
         cb, client = _make_callback()
         logs = {
@@ -286,7 +331,10 @@ class TestKerasCallbackMessageFormatting:
         assert "Training Loss:" in message
         assert "Validation Loss:" in message
 
-    @patch("slackker.callbacks.keras.plotting.generate_and_get_plots", return_value=["loss.png"])
+    @patch(
+        "slackker.callbacks.keras.plotting.generate_and_get_plots",
+        return_value=["loss.png"],
+    )
     def test_train_end_message_format(self, mock_plots):
         cb, client = _make_callback(send_plot=True)
         cb.train_loss = [0.60, 0.45, 0.35]
@@ -309,7 +357,11 @@ class TestKerasCallbackAdditionalBranches:
         with pytest.raises(ValueError, match="Unsupported export format"):
             KerasCallback(client=m, model_name="M", export=None)
 
-    @patch("slackker.callbacks.keras.network.check_connection_quick", new_callable=AsyncMock, return_value=True)
+    @patch(
+        "slackker.callbacks.keras.network.check_connection_quick",
+        new_callable=AsyncMock,
+        return_value=True,
+    )
     def test_on_epoch_end_incomplete_logs_skips_tracking(self, mock_check):
         cb, client = _make_callback()
         cb.on_epoch_end(batch=0, logs={"accuracy": 0.8, "loss": 0.2})
@@ -317,7 +369,11 @@ class TestKerasCallbackAdditionalBranches:
         assert cb.n_epochs == 1
         assert cb.train_loss == []
 
-    @patch("slackker.callbacks.keras.network.check_connection_quick", new_callable=AsyncMock, return_value=False)
+    @patch(
+        "slackker.callbacks.keras.network.check_connection_quick",
+        new_callable=AsyncMock,
+        return_value=False,
+    )
     def test_on_epoch_end_no_internet_still_tracks(self, mock_check):
         cb, client = _make_callback()
         logs = {
@@ -332,7 +388,10 @@ class TestKerasCallbackAdditionalBranches:
         assert cb.valid_loss == [0.50]
         assert len(client.messages) == 0
 
-    @patch("slackker.callbacks.keras.plotting.generate_and_get_plots", return_value=["loss.png"])
+    @patch(
+        "slackker.callbacks.keras.plotting.generate_and_get_plots",
+        return_value=["loss.png"],
+    )
     def test_train_end_message_contains_accuracy_percent(self, mock_plots):
         cb, client = _make_callback(send_plot=True)
         cb.train_loss = [0.60, 0.45, 0.35]
@@ -347,6 +406,7 @@ class TestKerasCallbackAdditionalBranches:
 
 
 # ── Auto-connect tests ───────────────────────────────────────
+
 
 class DisconnectedMockClient(MockClient):
     """MockClient that starts disconnected and records connect() calls."""
@@ -377,7 +437,7 @@ class TestAutoConnect:
         assert client.is_connected
 
     def test_skips_connect_when_already_connected(self):
-        client = MockClient()          # is_connected always True
+        client = MockClient()  # is_connected always True
         KerasCallback(client=client, model_name="M", export="png")
         assert client.is_connected
 
@@ -394,7 +454,7 @@ class TestKerasShimConnectFails:
 
         with warnings.catch_warnings(record=True):
             warnings.simplefilter("always")
-            obj = SlackUpdate(token="xoxb-test", channel="C123", ModelName="M")
+            obj = SlackUpdate(token="xoxb-test", channel_id="C123", ModelName="M")
 
         assert not hasattr(obj, "client")
 

--- a/tests/test_lightning.py
+++ b/tests/test_lightning.py
@@ -3,16 +3,18 @@ Tests for slackker.callbacks.lightning module.
 Tests cover the new unified LightningCallback class and backward-compatible shims.
 """
 
-import pytest
 import warnings
-import numpy as np
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
+
+import numpy as np
+import pytest
+
 from slackker.callbacks.lightning import LightningCallback, SlackUpdate, TelegramUpdate
 from slackker.core.client import BaseClient
 
-
 # ── Fixtures ──────────────────────────────────────────────────
+
 
 class MockClient(BaseClient):
     """Concrete test client that records calls."""
@@ -73,6 +75,7 @@ def _make_callback(
 
 # ── LightningCallback initialization ─────────────────────────
 
+
 class TestLightningCallbackInit:
     def test_init_stores_attributes(self):
         cb, _ = _make_callback()
@@ -87,18 +90,23 @@ class TestLightningCallbackInit:
     def test_init_requires_track_logs(self):
         m = MockClient()
         with pytest.raises(SystemExit):
-            LightningCallback(client=m, model_name="M", track_logs=None, monitor="val_loss")
+            LightningCallback(
+                client=m, model_name="M", track_logs=None, monitor="val_loss"
+            )
 
     def test_init_track_logs_must_be_list(self):
         m = MockClient()
         with pytest.raises(SystemExit):
-            LightningCallback(client=m, model_name="M", track_logs="train_loss", monitor="train_loss")
+            LightningCallback(
+                client=m, model_name="M", track_logs="train_loss", monitor="train_loss"
+            )
 
     def test_init_monitor_must_be_in_track_logs(self):
         m = MockClient()
         with pytest.raises(SystemExit):
             LightningCallback(
-                client=m, model_name="M",
+                client=m,
+                model_name="M",
                 track_logs=["train_loss", "val_loss"],
                 monitor="val_acc",
             )
@@ -112,12 +120,16 @@ class TestLightningCallbackInit:
         m = MockClient()
         with pytest.raises(ValueError, match="Unsupported export format"):
             LightningCallback(
-                client=m, model_name="M",
-                track_logs=["train_loss"], monitor="train_loss", export="bmp",
+                client=m,
+                model_name="M",
+                track_logs=["train_loss"],
+                monitor="train_loss",
+                export="bmp",
             )
 
 
 # ── on_fit_start ──────────────────────────────────────────────
+
 
 class TestOnFitStart:
     def test_posts_training_start(self):
@@ -130,13 +142,23 @@ class TestOnFitStart:
 
 # ── on_train_epoch_end ────────────────────────────────────────
 
+
 class TestOnTrainEpochEnd:
-    @patch("slackker.callbacks.lightning.network.check_connection_quick", new_callable=AsyncMock, return_value=True)
+    @patch(
+        "slackker.callbacks.lightning.network.check_connection_quick",
+        new_callable=AsyncMock,
+        return_value=True,
+    )
     def test_tracks_metrics_and_reports(self, mock_check):
         cb, client = _make_callback()
-        trainer = _trainer_with_metrics({
-            "train_loss": 0.90, "train_acc": 0.62, "val_loss": 0.84, "val_acc": 0.67,
-        })
+        trainer = _trainer_with_metrics(
+            {
+                "train_loss": 0.90,
+                "train_acc": 0.62,
+                "val_loss": 0.84,
+                "val_acc": 0.67,
+            }
+        )
         cb.on_train_epoch_end(trainer=trainer, pl_module=None)
 
         assert cb.n_epochs == 1
@@ -145,12 +167,21 @@ class TestOnTrainEpochEnd:
         assert len(client.messages) == 1
         assert "Epoch: 0" in client.messages[0]
 
-    @patch("slackker.callbacks.lightning.network.check_connection_quick", new_callable=AsyncMock, return_value=False)
+    @patch(
+        "slackker.callbacks.lightning.network.check_connection_quick",
+        new_callable=AsyncMock,
+        return_value=False,
+    )
     def test_skips_report_without_internet(self, mock_check):
         cb, client = _make_callback()
-        trainer = _trainer_with_metrics({
-            "train_loss": 0.90, "train_acc": 0.62, "val_loss": 0.84, "val_acc": 0.67,
-        })
+        trainer = _trainer_with_metrics(
+            {
+                "train_loss": 0.90,
+                "train_acc": 0.62,
+                "val_loss": 0.84,
+                "val_acc": 0.67,
+            }
+        )
         cb.on_train_epoch_end(trainer=trainer, pl_module=None)
 
         assert cb.n_epochs == 1
@@ -159,6 +190,7 @@ class TestOnTrainEpochEnd:
 
 
 # ── on_fit_end ────────────────────────────────────────────────
+
 
 class TestOnFitEnd:
     def test_reports_best_epoch_loss_monitor(self):
@@ -199,7 +231,10 @@ class TestOnFitEnd:
         found = any("monitor' was not provided" in m for m in client.messages)
         assert found
 
-    @patch("slackker.callbacks.lightning.plotting.generate_and_get_plots", return_value=["/tmp/loss.png", "/tmp/acc.png"])
+    @patch(
+        "slackker.callbacks.lightning.plotting.generate_and_get_plots",
+        return_value=["/tmp/loss.png", "/tmp/acc.png"],
+    )
     def test_uploads_plots_when_enabled(self, mock_plots):
         cb, client = _make_callback(send_plot=True)
         cb.training_logs = {"train_loss": [0.9, 0.7], "val_loss": [0.8, 0.6]}
@@ -213,20 +248,30 @@ class TestOnFitEnd:
 
 # ── Complete workflow ─────────────────────────────────────────
 
+
 class TestCompleteWorkflow:
-    @patch("slackker.callbacks.lightning.network.check_connection_quick", new_callable=AsyncMock, return_value=True)
-    @patch("slackker.callbacks.lightning.plotting.generate_and_get_plots", return_value=["/tmp/loss.png"])
+    @patch(
+        "slackker.callbacks.lightning.network.check_connection_quick",
+        new_callable=AsyncMock,
+        return_value=True,
+    )
+    @patch(
+        "slackker.callbacks.lightning.plotting.generate_and_get_plots",
+        return_value=["/tmp/loss.png"],
+    )
     def test_full_training(self, mock_plots, mock_check):
         cb, client = _make_callback(send_plot=True)
 
         cb.on_fit_start(trainer=None, pl_module=None)
         for epoch in range(6):
-            trainer = _trainer_with_metrics({
-                "train_loss": 0.90 - (0.05 * epoch),
-                "train_acc": 0.60 + (0.04 * epoch),
-                "val_loss": 0.85 - (0.04 * epoch),
-                "val_acc": 0.62 + (0.03 * epoch),
-            })
+            trainer = _trainer_with_metrics(
+                {
+                    "train_loss": 0.90 - (0.05 * epoch),
+                    "train_acc": 0.60 + (0.04 * epoch),
+                    "val_loss": 0.85 - (0.04 * epoch),
+                    "val_acc": 0.62 + (0.03 * epoch),
+                }
+            )
             cb.on_train_epoch_end(trainer=trainer, pl_module=None)
         cb.on_fit_end(trainer=None, pl_module=None)
 
@@ -237,6 +282,7 @@ class TestCompleteWorkflow:
 
 
 # ── Backward-compat shim tests ───────────────────────────────
+
 
 class TestSlackUpdateShim:
     @patch("slackker.callbacks.lightning.SlackClient")
@@ -249,8 +295,11 @@ class TestSlackUpdateShim:
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             cb = SlackUpdate(
-                token="xoxb-test", channel="C123", ModelName="M",
-                TrackLogs=["train_loss"], monitor="train_loss",
+                token="xoxb-test",
+                channel_id="C123",
+                ModelName="M",
+                TrackLogs=["train_loss"],
+                monitor="train_loss",
             )
             assert any(issubclass(x.category, DeprecationWarning) for x in w)
 
@@ -264,9 +313,13 @@ class TestSlackUpdateShim:
         with warnings.catch_warnings(record=True):
             warnings.simplefilter("always")
             cb = SlackUpdate(
-                token="xoxb-test", channel="C123", ModelName="M",
-                TrackLogs=["train_loss", "val_loss"], monitor="val_loss",
-                SendPlot=True, verbose=2,
+                token="xoxb-test",
+                channel_id="C123",
+                ModelName="M",
+                TrackLogs=["train_loss", "val_loss"],
+                monitor="val_loss",
+                SendPlot=True,
+                verbose=2,
             )
 
         assert cb.ModelName == "M"
@@ -278,8 +331,11 @@ class TestSlackUpdateShim:
         with warnings.catch_warnings(record=True):
             warnings.simplefilter("always")
             cb = SlackUpdate(
-                token=None, channel="C123", ModelName="M",
-                TrackLogs=["train_loss"], monitor="train_loss",
+                token=None,
+                channel_id="C123",
+                ModelName="M",
+                TrackLogs=["train_loss"],
+                monitor="train_loss",
             )
         assert not hasattr(cb, "client")
 
@@ -295,8 +351,10 @@ class TestTelegramUpdateShim:
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             cb = TelegramUpdate(
-                token="123:ABC", ModelName="M",
-                TrackLogs=["train_loss"], monitor="train_loss",
+                token="123:ABC",
+                ModelName="M",
+                TrackLogs=["train_loss"],
+                monitor="train_loss",
             )
             assert any(issubclass(x.category, DeprecationWarning) for x in w)
 
@@ -304,13 +362,16 @@ class TestTelegramUpdateShim:
         with warnings.catch_warnings(record=True):
             warnings.simplefilter("always")
             cb = TelegramUpdate(
-                token=None, ModelName="M",
-                TrackLogs=["train_loss"], monitor="train_loss",
+                token=None,
+                ModelName="M",
+                TrackLogs=["train_loss"],
+                monitor="train_loss",
             )
         assert not hasattr(cb, "client")
 
 
 # ── Auto-connect tests ───────────────────────────────────────
+
 
 class DisconnectedMockClient(MockClient):
     """MockClient that starts disconnected and records connect() calls."""
@@ -337,17 +398,21 @@ class TestAutoConnect:
         client = DisconnectedMockClient()
         assert not client.is_connected
         LightningCallback(
-            client=client, model_name="M",
-            track_logs=["train_loss"], monitor="train_loss",
+            client=client,
+            model_name="M",
+            track_logs=["train_loss"],
+            monitor="train_loss",
         )
         assert client.connect_calls == 1
         assert client.is_connected
 
     def test_skips_connect_when_already_connected(self):
-        client = MockClient()          # is_connected always True
+        client = MockClient()  # is_connected always True
         LightningCallback(
-            client=client, model_name="M",
-            track_logs=["train_loss"], monitor="train_loss",
+            client=client,
+            model_name="M",
+            track_logs=["train_loss"],
+            monitor="train_loss",
         )
         assert client.is_connected
 
@@ -365,8 +430,11 @@ class TestLightningShimConnectFails:
         with warnings.catch_warnings(record=True):
             warnings.simplefilter("always")
             obj = SlackUpdate(
-                token="xoxb-test", channel="C123", ModelName="M",
-                TrackLogs=["train_loss"], monitor="train_loss",
+                token="xoxb-test",
+                channel_id="C123",
+                ModelName="M",
+                TrackLogs=["train_loss"],
+                monitor="train_loss",
             )
 
         assert not hasattr(obj, "client")
@@ -381,8 +449,10 @@ class TestLightningShimConnectFails:
         with warnings.catch_warnings(record=True):
             warnings.simplefilter("always")
             obj = TelegramUpdate(
-                token="123:ABC", ModelName="M",
-                TrackLogs=["train_loss"], monitor="train_loss",
+                token="123:ABC",
+                ModelName="M",
+                TrackLogs=["train_loss"],
+                monitor="train_loss",
             )
 
         assert not hasattr(obj, "client")

--- a/tests/test_listener.py
+++ b/tests/test_listener.py
@@ -2,16 +2,16 @@
 
 import asyncio
 import time
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
 
 from slackker.core.client import BaseClient
 from slackker.core.models import IncomingMessage
 from slackker.listener import CommandHandler, MessagePoller
 
-
 # ── Shared helpers ────────────────────────────────────────────────────────────
+
 
 def _msg(
     text="hello",
@@ -65,11 +65,14 @@ class MockClient(BaseClient):
         pass
 
     async def fetch_messages(self, limit=10, since=None, thread_id=None):
-        self.fetch_calls.append({"limit": limit, "since": since, "thread_id": thread_id})
+        self.fetch_calls.append(
+            {"limit": limit, "since": since, "thread_id": thread_id}
+        )
         return list(self._messages)
 
 
 # ── IncomingMessage ───────────────────────────────────────────────────────────
+
 
 class TestIncomingMessage:
     def test_basic_construction(self):
@@ -107,14 +110,19 @@ class TestIncomingMessage:
 
     def test_default_raw_is_empty_dict(self):
         msg = IncomingMessage(
-            text="t", sender="s", sender_id="id",
-            timestamp="0", platform="p", is_bot=False,
+            text="t",
+            sender="s",
+            sender_id="id",
+            timestamp="0",
+            platform="p",
+            is_bot=False,
         )
         assert msg.raw == {}
         assert isinstance(msg.raw, dict)
 
 
 # ── BaseClient.cursor_from_message default ────────────────────────────────────
+
 
 class TestBaseCursorDefault:
     def test_default_returns_timestamp(self):
@@ -125,23 +133,26 @@ class TestBaseCursorDefault:
 
 # ── Slack fetch_messages ──────────────────────────────────────────────────────
 
+
 class TestSlackFetchMessages:
     @pytest.mark.asyncio
     async def test_channel_history_oldest_first(self):
         from slackker.core.slack import SlackClient
 
-        client = SlackClient(token="xoxb-test", channel="C123")
-        client._client.conversations_history = AsyncMock(return_value={
-            "messages": [
-                {"ts": "2000", "text": "newer", "user": "U2"},
-                {"ts": "1000", "text": "older", "user": "U1"},
-            ]
-        })
+        client = SlackClient(token="xoxb-test", channel_id="C123")
+        client._client.conversations_history = AsyncMock(
+            return_value={
+                "messages": [
+                    {"ts": "2000", "text": "newer", "user": "U2"},
+                    {"ts": "1000", "text": "older", "user": "U1"},
+                ]
+            }
+        )
 
         msgs = await client.fetch_messages(limit=10)
 
         assert len(msgs) == 2
-        assert msgs[0].text == "older"   # oldest first
+        assert msgs[0].text == "older"  # oldest first
         assert msgs[1].text == "newer"
         assert msgs[0].platform == "slack"
         assert msgs[0].timestamp == "1000"
@@ -150,7 +161,7 @@ class TestSlackFetchMessages:
     async def test_since_passed_as_oldest(self):
         from slackker.core.slack import SlackClient
 
-        client = SlackClient(token="xoxb-test", channel="C123")
+        client = SlackClient(token="xoxb-test", channel_id="C123")
         client._client.conversations_history = AsyncMock(return_value={"messages": []})
 
         await client.fetch_messages(limit=5, since="1234567890.000100")
@@ -163,15 +174,17 @@ class TestSlackFetchMessages:
     async def test_thread_replies_skips_parent(self):
         from slackker.core.slack import SlackClient
 
-        client = SlackClient(token="xoxb-test", channel="C123")
+        client = SlackClient(token="xoxb-test", channel_id="C123")
         # Slack always includes the parent message as the first element
-        client._client.conversations_replies = AsyncMock(return_value={
-            "messages": [
-                {"ts": "1000", "text": "parent", "user": "U1"},         # skipped
-                {"ts": "1001", "text": "reply1", "user": "U2", "thread_ts": "1000"},
-                {"ts": "1002", "text": "reply2", "user": "U3", "thread_ts": "1000"},
-            ]
-        })
+        client._client.conversations_replies = AsyncMock(
+            return_value={
+                "messages": [
+                    {"ts": "1000", "text": "parent", "user": "U1"},  # skipped
+                    {"ts": "1001", "text": "reply1", "user": "U2", "thread_ts": "1000"},
+                    {"ts": "1002", "text": "reply2", "user": "U3", "thread_ts": "1000"},
+                ]
+            }
+        )
 
         msgs = await client.fetch_messages(limit=10, thread_id="1000")
 
@@ -184,10 +197,12 @@ class TestSlackFetchMessages:
     async def test_bot_message_flagged(self):
         from slackker.core.slack import SlackClient
 
-        client = SlackClient(token="xoxb-test", channel="C123")
-        client._client.conversations_history = AsyncMock(return_value={
-            "messages": [{"ts": "1000", "text": "bot msg", "bot_id": "B123"}]
-        })
+        client = SlackClient(token="xoxb-test", channel_id="C123")
+        client._client.conversations_history = AsyncMock(
+            return_value={
+                "messages": [{"ts": "1000", "text": "bot msg", "bot_id": "B123"}]
+            }
+        )
 
         msgs = await client.fetch_messages()
         assert msgs[0].is_bot is True
@@ -196,9 +211,10 @@ class TestSlackFetchMessages:
     @pytest.mark.asyncio
     async def test_api_error_returns_empty_list(self):
         from slack_sdk.errors import SlackApiError
+
         from slackker.core.slack import SlackClient
 
-        client = SlackClient(token="xoxb-test", channel="C123")
+        client = SlackClient(token="xoxb-test", channel_id="C123")
         client._client.conversations_history = AsyncMock(
             side_effect=SlackApiError("fail", {"error": "not_authed"})
         )
@@ -208,12 +224,13 @@ class TestSlackFetchMessages:
     def test_cursor_from_message(self):
         from slackker.core.slack import SlackClient
 
-        client = SlackClient(token="xoxb-test", channel="C123")
+        client = SlackClient(token="xoxb-test", channel_id="C123")
         msg = _msg(timestamp="1699000000.000100", platform="slack")
         assert client.cursor_from_message(msg) == "1699000000.000100"
 
 
 # ── Telegram fetch_messages ───────────────────────────────────────────────────
+
 
 def _telegram_mock_ctx(updates_payload: dict):
     """Return a patched _make_async_client context that returns the given payload."""
@@ -237,15 +254,17 @@ class TestTelegramFetchMessages:
 
         client = TelegramClient(token="123:ABC", chat_id="99")
         payload = {
-            "result": [{
-                "update_id": 500,
-                "message": {
-                    "message_id": 10,
-                    "chat": {"id": 99},
-                    "from": {"id": 1, "first_name": "Alice", "is_bot": False},
-                    "text": "hello",
-                },
-            }]
+            "result": [
+                {
+                    "update_id": 500,
+                    "message": {
+                        "message_id": 10,
+                        "chat": {"id": 99},
+                        "from": {"id": 1, "first_name": "Alice", "is_bot": False},
+                        "text": "hello",
+                    },
+                }
+            ]
         }
         mock_ctx, _ = _telegram_mock_ctx(payload)
 
@@ -283,7 +302,8 @@ class TestTelegramFetchMessages:
                 {
                     "update_id": 1,
                     "message": {
-                        "message_id": 1, "chat": {"id": 99},
+                        "message_id": 1,
+                        "chat": {"id": 99},
                         "from": {"id": 1, "first_name": "Alice", "is_bot": False},
                         "text": "for me",
                     },
@@ -291,7 +311,8 @@ class TestTelegramFetchMessages:
                 {
                     "update_id": 2,
                     "message": {
-                        "message_id": 2, "chat": {"id": 77},  # different chat
+                        "message_id": 2,
+                        "chat": {"id": 77},  # different chat
                         "from": {"id": 2, "first_name": "Bob", "is_bot": False},
                         "text": "not for me",
                     },
@@ -316,7 +337,8 @@ class TestTelegramFetchMessages:
                 {
                     "update_id": 10,
                     "message": {
-                        "message_id": 11, "chat": {"id": 99},
+                        "message_id": 11,
+                        "chat": {"id": 99},
                         "from": {"id": 2, "first_name": "Bob", "is_bot": False},
                         "text": "reply to 10",
                         "reply_to_message": {"message_id": 10},
@@ -325,7 +347,8 @@ class TestTelegramFetchMessages:
                 {
                     "update_id": 11,
                     "message": {
-                        "message_id": 12, "chat": {"id": 99},
+                        "message_id": 12,
+                        "chat": {"id": 99},
                         "from": {"id": 3, "first_name": "Eve", "is_bot": False},
                         "text": "unrelated",
                     },
@@ -351,6 +374,7 @@ class TestTelegramFetchMessages:
 
 # ── Discord fetch_messages ────────────────────────────────────────────────────
 
+
 def _discord_mock_ctx(messages_payload):
     mock_resp = MagicMock()
     mock_resp.raise_for_status = MagicMock()
@@ -372,8 +396,16 @@ class TestDiscordFetchMessages:
 
         client = DiscordClient(token="Bot-token", channel_id="CH1")
         payload = [
-            {"id": "200", "content": "newer", "author": {"id": "U2", "username": "Bob", "bot": False}},
-            {"id": "100", "content": "older", "author": {"id": "U1", "username": "Alice", "bot": False}},
+            {
+                "id": "200",
+                "content": "newer",
+                "author": {"id": "U2", "username": "Bob", "bot": False},
+            },
+            {
+                "id": "100",
+                "content": "older",
+                "author": {"id": "U1", "username": "Alice", "bot": False},
+            },
         ]
         mock_ctx, _ = _discord_mock_ctx(payload)
 
@@ -406,12 +438,14 @@ class TestDiscordFetchMessages:
         client = DiscordClient(token="Bot-token", channel_id="CH1")
         payload = [
             {
-                "id": "200", "content": "reply",
+                "id": "200",
+                "content": "reply",
                 "author": {"id": "U2", "username": "Bob", "bot": False},
                 "message_reference": {"message_id": "100"},
             },
             {
-                "id": "300", "content": "unrelated",
+                "id": "300",
+                "content": "unrelated",
                 "author": {"id": "U3", "username": "Eve", "bot": False},
             },
         ]
@@ -430,7 +464,11 @@ class TestDiscordFetchMessages:
 
         client = DiscordClient(token="Bot-token", channel_id="CH1")
         payload = [
-            {"id": "1", "content": "bot says hi", "author": {"id": "B1", "username": "mybot", "bot": True}},
+            {
+                "id": "1",
+                "content": "bot says hi",
+                "author": {"id": "B1", "username": "mybot", "bot": True},
+            },
         ]
         mock_ctx, _ = _discord_mock_ctx(payload)
 
@@ -449,6 +487,7 @@ class TestDiscordFetchMessages:
 
 # ── Teams fetch_messages ──────────────────────────────────────────────────────
 
+
 def _teams_mock_ctx(value_payload):
     mock_resp = MagicMock()
     mock_resp.raise_for_status = MagicMock()
@@ -466,6 +505,7 @@ def _teams_mock_ctx(value_payload):
 class TestTeamsFetchMessages:
     def _connected_client(self):
         from slackker.core.teams import TeamsClient
+
         client = TeamsClient(app_id="app-id", chat_id="19:chat@thread.v2")
         client._access_token = "fake-token"
         client._token_expiry = time.time() + 3600
@@ -474,12 +514,14 @@ class TestTeamsFetchMessages:
     @pytest.mark.asyncio
     async def test_fetch_basic_message(self):
         client = self._connected_client()
-        payload = [{
-            "id": "msg1",
-            "body": {"content": "hello teams"},
-            "from": {"user": {"id": "U1", "displayName": "Alice"}},
-            "createdDateTime": "2024-01-01T10:00:00Z",
-        }]
+        payload = [
+            {
+                "id": "msg1",
+                "body": {"content": "hello teams"},
+                "from": {"user": {"id": "U1", "displayName": "Alice"}},
+                "createdDateTime": "2024-01-01T10:00:00Z",
+            }
+        ]
         mock_ctx, _ = _teams_mock_ctx(payload)
 
         with patch("slackker.utils.network._make_async_client", return_value=mock_ctx):
@@ -556,12 +598,14 @@ class TestTeamsFetchMessages:
     @pytest.mark.asyncio
     async def test_bot_message_flagged(self):
         client = self._connected_client()
-        payload = [{
-            "id": "msg1",
-            "body": {"content": "automated"},
-            "from": {"application": {"id": "APP1", "displayName": "MyBot"}},
-            "createdDateTime": "2024-01-01T10:00:00Z",
-        }]
+        payload = [
+            {
+                "id": "msg1",
+                "body": {"content": "automated"},
+                "from": {"application": {"id": "APP1", "displayName": "MyBot"}},
+                "createdDateTime": "2024-01-01T10:00:00Z",
+            }
+        ]
         mock_ctx, _ = _teams_mock_ctx(payload)
 
         with patch("slackker.utils.network._make_async_client", return_value=mock_ctx):
@@ -572,6 +616,7 @@ class TestTeamsFetchMessages:
     @pytest.mark.asyncio
     async def test_not_connected_returns_empty(self):
         from slackker.core.teams import TeamsClient
+
         client = TeamsClient(app_id="app-id", chat_id="19:chat@thread.v2")
         # _access_token is None -> not connected; connect() would do device flow -> mock it
         client.connect = AsyncMock(return_value=False)
@@ -581,6 +626,7 @@ class TestTeamsFetchMessages:
 
 
 # ── MessagePoller ─────────────────────────────────────────────────────────────
+
 
 class TestMessagePoller:
     @pytest.mark.asyncio
@@ -854,6 +900,7 @@ class TestMessagePoller:
 
 
 # ── CommandHandler ────────────────────────────────────────────────────────────
+
 
 class TestCommandHandler:
     def test_command_decorator_registers_with_prefix(self):

--- a/uv.lock
+++ b/uv.lock
@@ -2858,7 +2858,7 @@ wheels = [
 
 [[package]]
 name = "slackker"
-version = "1.4.8"
+version = "1.4.9"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/website/index.html
+++ b/website/index.html
@@ -435,8 +435,11 @@ train_model(epochs=20)</code></pre>
               <span class="setup-step-num">3</span>
               <div>
                 <strong>Invite the Bot to your Server</strong>
-                <p>Sidebar&nbsp; ➤ &nbsp;<strong>OAuth2</strong>&nbsp; ➤ &nbsp;<strong>URL Generator</strong>&nbsp; ➤ &nbsp;Select <code>bot</code> scope&nbsp; ➤ &nbsp;Set permissions <code>Send Messages</code> &amp; <code>Attach Files</code>.&nbsp; ➤ &nbsp;Visit the generated URL to invite the bot.</p>
-              </div>
+                <p>Sidebar&nbsp; ➤ &nbsp;<strong>OAuth2</strong>&nbsp; ➤ &nbsp;<strong>URL Generator</strong>&nbsp; ➤ &nbsp;Select <code>bot</code> scope&nbsp; ➤ &nbsp;Set below permissions:</p>
+                <div class="setup-badges">
+                    <code>Send Messages</code><code>Attach Files</code>
+                </div>
+                <p>Visit the generated URL to invite the bot.</p>
             </li>
             <li>
               <span class="setup-step-num">4</span>

--- a/website/index.html
+++ b/website/index.html
@@ -339,7 +339,7 @@ train_model(epochs=20)</code></pre>
               <div>
                 <strong>Add the app to a channel &amp; get the Channel ID</strong>
                 <p>In Slack, open the target channel&nbsp; ➤ &nbsp;click the channel name&nbsp; ➤ &nbsp;<strong>Integrations</strong>&nbsp; ➤ &nbsp;<strong>Add an App</strong>. Then copy the Channel ID from the channel description (starts with <code>C</code>):</p>
-                <code class="setup-token">SlackClient(token="xoxb-...", channel="C04AAB77ABC")</code>
+                <code class="setup-token">SlackClient(token="xoxb-...", channel_id="C04AAB77ABC")</code>
               </div>
             </li>
           </ol>

--- a/website/index.html
+++ b/website/index.html
@@ -741,7 +741,7 @@ main()</code></pre>
     <div class="footer-bar">
       <div class="footer-status">
         <span class="footer-pulse"></span>
-        <span>slackker v1.4.8</span>
+        <span>slackker v1.4.9</span>
       </div>
       <div class="footer-links">
         <a href="https://github.com/siddheshgunjal/slackker" target="_blank" rel="noreferrer">GitHub</a>

--- a/website/script.js
+++ b/website/script.js
@@ -144,7 +144,7 @@ from slackker.callbacks.simple import SimpleCallback
 
 client = SlackClient(
     token="xoxb-your-bot-token",
-    channel="A04AAB77ABC",
+    channel_id="A04AAB77ABC",
     verbose=1
 )
 notify = SimpleCallback(client)
@@ -210,7 +210,7 @@ from slackker.callbacks.simple import SimpleCallback
 
 client = SlackClient(
     token="xoxb-your-bot-token",
-    channel="A04AAB77ABC",
+    channel_id="A04AAB77ABC",
     verbose=1
 )
 notify = SimpleCallback(client)
@@ -286,7 +286,7 @@ from slackker.callbacks.simple import SimpleCallback
 
 client = SlackClient(
     token="xoxb-your-bot-token",
-    channel="A04AAB77ABC",
+    channel_id="A04AAB77ABC",
     verbose=1
 )
 notify = SimpleCallback(client)
@@ -397,7 +397,7 @@ from slackker.callbacks.simple import SimpleCallback
 
 client = SlackClient(
     token="xoxb-your-bot-token",
-    channel="A04AAB77ABC",
+    channel_id="A04AAB77ABC",
     verbose=1
 )
 notifier = SimpleCallback(client)
@@ -546,7 +546,7 @@ from slackker.callbacks.simple import SimpleCallback
 
 client = SlackClient(
     token="xoxb-your-bot-token",
-    channel="A04AAB77ABC",
+    channel_id="A04AAB77ABC",
     verbose=1
 )
 notifier = SimpleCallback(client)
@@ -680,7 +680,7 @@ from slackker.callbacks.keras import KerasCallback
 
 client = SlackClient(
     token="xoxb-your-bot-token",
-    channel="A04AAB77ABC",
+    channel_id="A04AAB77ABC",
     verbose=1
 )
 slackker_cb = KerasCallback(
@@ -771,7 +771,7 @@ from slackker.callbacks.lightning import LightningCallback
 
 client = SlackClient(
     token="xoxb-your-bot-token",
-    channel="A04AAB77ABC",
+    channel_id="A04AAB77ABC",
     verbose=1
 )
 slackker_cb = LightningCallback(


### PR DESCRIPTION
## Summary
This PR standardizes the parameter used to specify the target channel across different client backends. Specifically, it renames `channel` to `channel_id` in the `SlackClient` to maintain consistency with the `DiscordClient` and other project conventions.

## Change Log

### 🚀 Core API Changes
- **`SlackClient`**: Renamed the `channel` parameter to `channel_id` in the constructor and updated the corresponding property and internal API calls (message sending, file uploads, and history fetching).
- **Callback Shims**: Updated deprecated `SlackUpdate` classes in `basic.py`, `keras.py`, and `lightning.py` to accept `channel_id` instead of `channel` to reflect the underlying client change.

### 📝 Documentation & Website
- **`README.md`**: Updated all Slack usage examples and the parameter reference table to use `channel_id`.
- **Website (`index.html` & `script.js`)**: 
    - Updated the Slack setup guide and all interactive code snippets to use `channel_id`.
    - Improved the Discord setup guide by adding a "setup badges" section for required permissions.

### 🧪 Tests & Versioning
- **Test Suite**: Updated all occurrences of `channel` to `channel_id` across `test_basic.py`, `test_core.py`, `test_keras.py`, `test_lightning.py`, and `test_listener.py`.
- **Version Bump**: Incremented package version from `1.4.8` $\rightarrow$ `1.4.9` in `pyproject.toml`, `slackker/__init__.py`, and `uv.lock`.

## Validation
- All 298 tests passed via `pytest` after the changes were applied.
- Verified that deprecated shims still function correctly while emitting the appropriate `DeprecationWarning`.