### PR TITLE
Replace `sys.exit()` with `ValueError` in LightningCallback validation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "slackker"
-version = "2.0.2"
+version = "2.0.3"
 description = "Python package for monitoring your pipeline & Model training status in real-time on Slack, Telegram and Microsoft Teams."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/slackker/__init__.py
+++ b/slackker/__init__.py
@@ -13,7 +13,7 @@ from slackker.mcp.handler import MCPHandler
 
 __author__ = "Siddhesh Gunjal"
 __email__ = "siddhu19@live.com"
-__version__ = "2.0.2"
+__version__ = "2.0.3"
 
 # module level doc-string
 __doc__ = """

--- a/slackker/callbacks/lightning.py
+++ b/slackker/callbacks/lightning.py
@@ -1,4 +1,3 @@
-import sys
 from datetime import datetime
 
 import numpy as np
@@ -44,15 +43,14 @@ class LightningCallback(Callback):
             )
 
         if track_logs is None:
-            log.error("Provide at least 1 log type for sending update.")
-            sys.exit()
+            raise ValueError("Provide at least 1 log type for sending update.")
         if not isinstance(track_logs, list):
-            log.error("'track_logs' must be a list, e.g. ['train_loss', 'val_loss']")
-            sys.exit()
+            raise ValueError(
+                "'track_logs' must be a list, e.g. ['train_loss', 'val_loss']"
+            )
 
         if monitor is not None and monitor not in track_logs:
-            log.error(f"'monitor' value '{monitor}' not found in 'track_logs'")
-            sys.exit()
+            raise ValueError(f"'monitor' value '{monitor}' not found in 'track_logs'")
         elif monitor is None:
             log.warning("'monitor' not provided, will skip reporting Best Epoch")
 

--- a/tests/test_lightning.py
+++ b/tests/test_lightning.py
@@ -84,21 +84,24 @@ class TestLightningCallbackInit:
 
     def test_init_requires_track_logs(self):
         m = MockClient()
-        with pytest.raises(SystemExit):
+        with pytest.raises(ValueError, match="Provide at least 1 log type"):
             LightningCallback(
                 client=m, model_name="M", track_logs=None, monitor="val_loss"
             )
 
     def test_init_track_logs_must_be_list(self):
         m = MockClient()
-        with pytest.raises(SystemExit):
+        with pytest.raises(ValueError, match="'track_logs' must be a list"):
             LightningCallback(
-                client=m, model_name="M", track_logs="train_loss", monitor="train_loss"  # type: ignore
+                client=m,
+                model_name="M",
+                track_logs="train_loss",
+                monitor="train_loss",  # type: ignore
             )
 
     def test_init_monitor_must_be_in_track_logs(self):
         m = MockClient()
-        with pytest.raises(SystemExit):
+        with pytest.raises(ValueError, match="'monitor' value 'val_acc' not found"):
             LightningCallback(
                 client=m,
                 model_name="M",

--- a/uv.lock
+++ b/uv.lock
@@ -3617,7 +3617,7 @@ wheels = [
 
 [[package]]
 name = "slackker"
-version = "2.0.1"
+version = "2.0.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Change log

**Changed**
- Replaced `sys.exit()` calls with `raise ValueError()` in `LightningCallback.__init__()` for all input validation failures (`track_logs` missing, wrong type, `monitor` not in `track_logs`). This allows callers to catch and handle validation errors gracefully instead of crashing the process, and removes the now-unused `sys` import.

**Tests**
- Updated tests in `test_lightning.py` to assert `ValueError` (with match patterns) instead of `SystemExit`, keeping coverage aligned with the new behavior.