### PR TITLE
Make KerasCallback metric tracking configurable via `track_logs` and `monitor`

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,6 +538,8 @@ history = model.fit(
 | `model_name` | `str` | _required_ | Name used in messages and plot titles |
 | `export` | `str` | `"png"` | Plot format _(eps, jpeg, jpg, pdf, pgf, png, ps, raw, rgba, svg, svgz, tif, tiff)_ |
 | `send_plot` | `bool` | `False` | Send training/validation plots when training ends |
+| `track_logs` | `dict[str, str] \| None` | `None` | Maps attribute names to Keras `logs` keys. Defaults to `{"train_loss": "loss", "train_acc": "accuracy", "valid_loss": "val_loss", "valid_acc": "val_accuracy"}`. Customise for non-standard metric names. |
+| `monitor` | `str` | `"valid_loss"` | Attribute name from `track_logs` used to determine the best epoch. Loss-like metrics use `argmin`; others use `argmax`. |
 
 </details>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "slackker"
-version = "2.0.3"
+version = "2.0.4"
 description = "Python package for monitoring your pipeline & Model training status in real-time on Slack, Telegram and Microsoft Teams."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/slackker/__init__.py
+++ b/slackker/__init__.py
@@ -13,7 +13,7 @@ from slackker.mcp.handler import MCPHandler
 
 __author__ = "Siddhesh Gunjal"
 __email__ = "siddhu19@live.com"
-__version__ = "2.0.3"
+__version__ = "2.0.4"
 
 # module level doc-string
 __doc__ = """

--- a/slackker/callbacks/keras.py
+++ b/slackker/callbacks/keras.py
@@ -8,7 +8,40 @@ from slackker.utils import network, plotting
 
 
 class KerasCallback(Callback):
-    """Unified Keras training callback that works with any client backend."""
+    """Unified Keras training callback that works with any client backend.
+
+    Parameters
+    ----------
+    client : BaseClient
+        The messaging platform client to send notifications through.
+    model_name : str
+        Human-readable name for the model (used in messages and plot titles).
+    export : str
+        Image format for training plots. Defaults to ``"png"``.
+    send_plot : bool
+        If ``True``, upload training-curve plots at the end of training.
+        Defaults to ``False``.
+    track_logs : dict[str, str] | None
+        Mapping of attribute names to Keras ``logs`` dictionary keys.
+        The values are appended to lists stored on the callback instance
+        (e.g. ``self.train_loss``, ``self.val_acc``).
+
+        Defaults to the standard Keras convention::
+
+            {
+                "train_loss":  "loss",
+                "train_acc":   "accuracy",
+                "valid_loss":  "val_loss",
+                "valid_acc":   "val_accuracy",
+            }
+
+        Pass a custom mapping when your model uses non-standard metric
+        names (e.g. ``{"train_loss": "loss", "train_auc": "auc"}``).
+    monitor : str
+        Attribute name (from *track_logs*) used to determine the best
+        epoch.  Lower is better when the name contains ``"loss"``;
+        otherwise higher is better.  Defaults to ``"valid_loss"``.
+    """
 
     SUPPORTED_FORMATS = (
         "eps",
@@ -26,17 +59,35 @@ class KerasCallback(Callback):
         "tiff",
     )
 
+    _DEFAULT_TRACK_LOGS: dict[str, str] = {
+        "train_loss": "loss",
+        "train_acc": "accuracy",
+        "valid_loss": "val_loss",
+        "valid_acc": "val_accuracy",
+    }
+
     def __init__(
         self,
         client: BaseClient,
         model_name: str,
         export: str = "png",
         send_plot: bool = False,
+        track_logs: dict[str, str] | None = None,
+        monitor: str = "valid_loss",
     ):
         super().__init__()
         if export not in self.SUPPORTED_FORMATS:
             raise ValueError(
                 f"Unsupported export format '{export}'. Supported: {self.SUPPORTED_FORMATS}"
+            )
+
+        self.track_logs = track_logs or dict(self._DEFAULT_TRACK_LOGS)
+        self.monitor = monitor
+
+        if monitor not in self.track_logs:
+            raise ValueError(
+                f"'monitor' value '{monitor}' not found in 'track_logs' keys. "
+                f"Available keys: {list(self.track_logs)}"
             )
 
         self.client = client
@@ -47,10 +98,11 @@ class KerasCallback(Callback):
         if not client.is_connected:
             _run_sync(client.connect())
 
-        self.train_acc = []
-        self.valid_acc = []
-        self.train_loss = []
-        self.valid_loss = []
+        # Metric lists — populated from logs using self.track_logs mapping
+        self.train_acc: list[float] = []
+        self.valid_acc: list[float] = []
+        self.train_loss: list[float] = []
+        self.valid_loss: list[float] = []
         self.n_epochs = 0
 
     def on_train_begin(self, logs=None):
@@ -60,13 +112,13 @@ class KerasCallback(Callback):
 
     def on_epoch_end(self, epoch, logs=None):
         logs = logs or {}
-        log_values = list(logs.values())
 
-        if len(log_values) >= 4:
-            self.train_acc.append(log_values[0])
-            self.train_loss.append(log_values[1])
-            self.valid_acc.append(log_values[2])
-            self.valid_loss.append(log_values[3])
+        # Extract metrics by key name (not positional index).
+        for attr_name, log_key in self.track_logs.items():
+            if log_key in logs:
+                metric_list: list[float] = getattr(self, attr_name, None)
+                if metric_list is not None:
+                    metric_list.append(float(logs[log_key]))
 
         message = f"Epoch: {self.n_epochs}"
         if self.train_loss:
@@ -83,19 +135,31 @@ class KerasCallback(Callback):
         self.n_epochs += 1
 
     def on_train_end(self, logs=None):
-        if self.valid_loss:
-            best_epoch = int(np.argmin(self.valid_loss))
-            val_loss = self.valid_loss[best_epoch]
-            train_loss = self.train_loss[best_epoch]
-            val_acc = self.valid_acc[best_epoch] if self.valid_acc else 0
-            train_acc = self.train_acc[best_epoch] if self.train_acc else 0
+        monitor_values: list[float] = getattr(self, self.monitor, None) or []
+
+        if monitor_values:
+            # Lower is better for loss-like metrics, higher otherwise.
+            if "loss" in self.monitor.lower():
+                best_epoch = int(np.argmin(monitor_values))
+            else:
+                best_epoch = int(np.argmax(monitor_values))
 
             self.client.send_message_sync(
                 f"Trained for {self.n_epochs} epochs. Best epoch was {best_epoch}."
             )
-            self.client.send_message_sync(
-                f"Best validation loss = {val_loss:.4f}, Training Loss = {train_loss:.4f}, Best Accuracy = {100 * val_acc:.4f}%"
-            )
+
+            # Build a detailed best-epoch summary from all tracked metrics.
+            parts: list[str] = []
+            for attr_name in self.track_logs:
+                values: list[float] = getattr(self, attr_name, None) or []
+                if len(values) > best_epoch:
+                    val = values[best_epoch]
+                    if "acc" in attr_name.lower():
+                        parts.append(f"{attr_name} = {100 * val:.4f}%")
+                    else:
+                        parts.append(f"{attr_name} = {val:.4f}")
+            if parts:
+                self.client.send_message_sync(", ".join(parts))
 
         training_logs = {
             "train_loss": self.train_loss,

--- a/tests/test_keras.py
+++ b/tests/test_keras.py
@@ -65,11 +65,33 @@ class TestKerasCallbackInit:
         assert cb.n_epochs == 0
         assert cb.train_loss == []
         assert cb.train_acc == []
+        assert cb.track_logs == KerasCallback._DEFAULT_TRACK_LOGS
+        assert cb.monitor == "valid_loss"
 
     def test_init_rejects_bad_format(self):
         m = MockClient()
         with pytest.raises(ValueError, match="Unsupported export format"):
             KerasCallback(client=m, model_name="M", export="bmp")
+
+    def test_init_rejects_monitor_not_in_track_logs(self):
+        m = MockClient()
+        with pytest.raises(ValueError, match="'monitor' value 'f1' not found"):
+            KerasCallback(
+                client=m,
+                model_name="M",
+                monitor="f1",
+            )
+
+    def test_init_custom_track_logs(self):
+        m = MockClient()
+        cb = KerasCallback(
+            client=m,
+            model_name="M",
+            track_logs={"train_loss": "loss", "train_auc": "auc"},
+            monitor="train_auc",
+        )
+        assert cb.track_logs == {"train_loss": "loss", "train_auc": "auc"}
+        assert cb.monitor == "train_auc"
 
 
 # ── on_train_begin ────────────────────────────────────────────
@@ -95,7 +117,12 @@ class TestOnEpochEnd:
     )
     def test_tracks_metrics_and_reports(self, mock_check):
         cb, client = _make_callback()
-        logs = {"accuracy": 0.85, "loss": 0.45, "val_accuracy": 0.80, "val_loss": 0.50}
+        logs = {
+            "accuracy": 0.85,
+            "loss": 0.45,
+            "val_accuracy": 0.80,
+            "val_loss": 0.50,
+        }
         cb.on_epoch_end(epoch=0, logs=logs)
 
         assert cb.n_epochs == 1
@@ -111,7 +138,12 @@ class TestOnEpochEnd:
     )
     def test_skips_report_without_internet(self, mock_check):
         cb, client = _make_callback()
-        logs = {"accuracy": 0.85, "loss": 0.45, "val_accuracy": 0.80, "val_loss": 0.50}
+        logs = {
+            "accuracy": 0.85,
+            "loss": 0.45,
+            "val_accuracy": 0.80,
+            "val_loss": 0.50,
+        }
         cb.on_epoch_end(epoch=0, logs=logs)
 
         assert cb.n_epochs == 1
@@ -155,6 +187,8 @@ class TestOnTrainEnd:
 
         found_best = any("Best epoch was 2" in m for m in client.messages)
         assert found_best
+        # Detailed summary uses the attribute names from track_logs.
+        assert any("valid_loss = 0.3800" in m for m in client.messages)
 
     @patch(
         "slackker.callbacks.keras.plotting.generate_and_get_plots",
@@ -177,8 +211,25 @@ class TestOnTrainEnd:
         cb, client = _make_callback()
         cb.n_epochs = 0
         cb.on_train_end()
-        # No messages about best epoch when no data
         assert not any("Best epoch" in m for m in client.messages)
+
+    def test_monitor_acc_selects_highest_epoch(self):
+        """When monitor is an accuracy metric, best epoch = argmax."""
+        m = MockClient()
+        cb = KerasCallback(
+            client=m,
+            model_name="M",
+            monitor="valid_acc",
+        )
+        cb.train_loss = [0.6, 0.4, 0.3]
+        cb.train_acc = [0.7, 0.8, 0.9]
+        cb.valid_loss = [0.65, 0.50, 0.55]
+        cb.valid_acc = [0.65, 0.75, 0.70]
+        cb.n_epochs = 3
+
+        cb.on_train_end()
+
+        assert any("Best epoch was 1" in msg for msg in m.messages)
 
 
 # ── Log ordering ──────────────────────────────────────────────
@@ -190,14 +241,16 @@ class TestLogOrdering:
         new_callable=AsyncMock,
         return_value=True,
     )
-    def test_logs_stored_in_order(self, mock_check):
+    def test_logs_extracted_by_key_name(self, mock_check):
+        """Metrics are looked up by key name — dict ordering does not matter."""
         cb, _ = _make_callback()
         for i in range(3):
+            # Shuffle insertion order to prove key-based lookup is order-independent.
             logs = {
-                "accuracy": 0.5 + i * 0.1,
-                "loss": 0.9 - i * 0.1,
-                "val_accuracy": 0.4 + i * 0.1,
                 "val_loss": 1.0 - i * 0.1,
+                "loss": 0.9 - i * 0.1,
+                "accuracy": 0.5 + i * 0.1,
+                "val_accuracy": 0.4 + i * 0.1,
             }
             cb.on_epoch_end(epoch=i, logs=logs)
 
@@ -205,6 +258,43 @@ class TestLogOrdering:
         assert cb.train_loss == pytest.approx([0.9, 0.8, 0.7])
         assert cb.valid_acc == pytest.approx([0.4, 0.5, 0.6])
         assert cb.valid_loss == pytest.approx([1.0, 0.9, 0.8])
+
+    @patch(
+        "slackker.callbacks.keras.network.check_connection_quick",
+        new_callable=AsyncMock,
+        return_value=True,
+    )
+    def test_custom_track_logs_extracts_only_mapped_keys(self, mock_check):
+        """When track_logs is customised, only mapped metrics are tracked."""
+        m = MockClient()
+        cb = KerasCallback(
+            client=m,
+            model_name="M",
+            track_logs={"train_loss": "loss", "val_auc": "val_auc"},
+            monitor="val_auc",
+        )
+        logs = {"loss": 0.5, "accuracy": 0.9, "val_loss": 0.6, "val_auc": 0.75}
+        cb.on_epoch_end(epoch=0, logs=logs)
+
+        assert cb.train_loss == [0.5]
+        # accuracy and val_loss are NOT in track_logs → default lists stay empty.
+        assert cb.train_acc == []
+        assert cb.valid_loss == []
+
+    @patch(
+        "slackker.callbacks.keras.network.check_connection_quick",
+        new_callable=AsyncMock,
+        return_value=True,
+    )
+    def test_incomplete_logs_tracks_available_metrics(self, mock_check):
+        """Only metrics whose keys appear in logs are tracked."""
+        cb, client = _make_callback()
+        cb.on_epoch_end(epoch=0, logs={"accuracy": 0.8, "loss": 0.2})
+        assert cb.n_epochs == 1
+        assert cb.train_acc == [0.8]
+        assert cb.train_loss == [0.2]
+        assert cb.valid_loss == []  # val_loss key not present
+        assert cb.valid_acc == []  # val_accuracy key not present
 
 
 # ── Complete workflow ─────────────────────────────────────────
@@ -278,6 +368,28 @@ class TestKerasCallbackMessageFormatting:
 
         assert len(client.messages) >= 2
         assert any("3 epochs" in m for m in client.messages)
+        # Best-epoch summary uses the attribute names from track_logs.
+        assert any("valid_loss = 0.4000" in m for m in client.messages)
+
+    @patch(
+        "slackker.callbacks.keras.plotting.generate_and_get_plots",
+        return_value=["loss.png"],
+    )
+    def test_train_end_message_contains_accuracy_percent(self, mock_plots):
+        cb, client = _make_callback(send_plot=True)
+        cb.train_loss = [0.60, 0.45, 0.35]
+        cb.train_acc = [0.70, 0.80, 0.85]
+        cb.valid_loss = [0.65, 0.50, 0.40]
+        cb.valid_acc = [0.65, 0.75, 0.82]
+        cb.n_epochs = 3
+
+        cb.on_train_end()
+
+        # Accuracy metrics are formatted as percentages in the summary.
+        assert any(
+            "valid_acc = 82.0000%" in m or "train_acc = 85.0000%" in m
+            for m in client.messages
+        )
 
 
 class TestKerasCallbackAdditionalBranches:
@@ -287,18 +399,6 @@ class TestKerasCallbackAdditionalBranches:
         m = MockClient()
         with pytest.raises(ValueError, match="Unsupported export format"):
             KerasCallback(client=m, model_name="M", export=None)  # type: ignore
-
-    @patch(
-        "slackker.callbacks.keras.network.check_connection_quick",
-        new_callable=AsyncMock,
-        return_value=True,
-    )
-    def test_on_epoch_end_incomplete_logs_skips_tracking(self, mock_check):
-        cb, client = _make_callback()
-        cb.on_epoch_end(epoch=0, logs={"accuracy": 0.8, "loss": 0.2})
-        # With < 4 log values, metrics are not tracked but epoch still counts
-        assert cb.n_epochs == 1
-        assert cb.train_loss == []
 
     @patch(
         "slackker.callbacks.keras.network.check_connection_quick",
@@ -318,22 +418,6 @@ class TestKerasCallbackAdditionalBranches:
         assert cb.n_epochs == 1
         assert cb.valid_loss == [0.50]
         assert len(client.messages) == 0
-
-    @patch(
-        "slackker.callbacks.keras.plotting.generate_and_get_plots",
-        return_value=["loss.png"],
-    )
-    def test_train_end_message_contains_accuracy_percent(self, mock_plots):
-        cb, client = _make_callback(send_plot=True)
-        cb.train_loss = [0.60, 0.45, 0.35]
-        cb.train_acc = [0.70, 0.80, 0.85]
-        cb.valid_loss = [0.65, 0.50, 0.40]
-        cb.valid_acc = [0.65, 0.75, 0.82]
-        cb.n_epochs = 3
-
-        cb.on_train_end()
-
-        assert any("Best Accuracy =" in m and "%" in m for m in client.messages)
 
 
 # ── Auto-connect tests ───────────────────────────────────────

--- a/uv.lock
+++ b/uv.lock
@@ -3617,7 +3617,7 @@ wheels = [
 
 [[package]]
 name = "slackker"
-version = "2.0.3"
+version = "2.0.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Change log

**Added**
- New `track_logs` parameter (`dict[str, str] | None`) mapping attribute names to Keras log keys, defaulting to the standard `loss`, `accuracy`, `val_loss`, `val_accuracy` convention. Users can now track custom metric names (e.g. `{"train_loss": "loss", "train_auc": "auc"}`).
- New `monitor` parameter (`str`, default `"valid_loss"`) specifying which metric determines the best epoch. Lower is better for loss-like names, higher for accuracy-like names.
- Input validation raising `ValueError` when `monitor` is not a key in `track_logs`.
- Comprehensive NumPy-style docstring documenting all parameters.

**Changed**
- `on_epoch_end` no longer appends metrics by positional index; it looks up each tracked key by name from the `logs` dict. This makes tracking robust to metric ordering and allows partial logs (only available metrics are appended).
- `on_train_end` uses the `monitor` attribute to find the best epoch (argmin for loss, argmax for accuracy) and dynamically builds a summary message from all tracked metric values at that epoch.
- Accuracy values in the best-epoch summary are formatted as percentages.

**Tests**
- Added tests for custom `track_logs`, custom `monitor`, monitor-not-found validation, accuracy-based best-epoch selection, incomplete logs with only some metrics, and percentage formatting in the summary message.
- Updated existing tests to use key-based `logs` dicts (shuffling insertion order to confirm order-independence).